### PR TITLE
Create signed tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.serverless/
 /bin/
+/gnupg/
 *.env
 *.pem

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.serverless/
 /bin/
+/gnupg/
 *.env
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /.serverless/
 /bin/
-/gnupg/
 *.env
-*.pem

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,7 @@ fi
 rm -rf bin
 mkdir bin
 chmod 644 "$PEM"
+rm -f "$GPG/S.gpg-agent"
 find "$GPG" -type d -exec chmod 700 {} \;
 find "$GPG" -type f -exec chmod 600 {} \;
 tar -cf "$RESOURCES" "$GPG" "$PEM"

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,25 @@
 #!/usr/bin/env bash
 
 FNS=("github")
+PEM="tag-bot.pem"
+GPG="gnupg"
+RESOURCES="bin/resources.tar"
+
+if [ ! -f  "$PEM" ]; then
+    echo "File $PEM does not exist"
+    exit 1
+fi
+if [ ! -d  "$GPG" ]; then
+    echo "Directory $GPG does not exist"
+    exit 1
+fi
 
 rm -rf bin
 mkdir bin
+chmod 644 "$PEM"
+find "$GPG" -type d -exec chmod 700 {} \;
+find "$GPG" -type f -exec chmod 600 {} \;
+tar -cf "$RESOURCES" "$GPG" "$PEM"
 
 for fn in "${FNS[@]}"; do
   (

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ rm -rf bin
 mkdir bin
 cp *.pem bin
 chmod 644 bin/*.pem
+cp -r gnupg bin
 
 for fn in "${FNS[@]}"; do
   (

--- a/build.sh
+++ b/build.sh
@@ -4,9 +4,6 @@ FNS=("github")
 
 rm -rf bin
 mkdir bin
-cp *.pem bin
-chmod 644 bin/*.pem
-cp -r gnupg bin
 
 for fn in "${FNS[@]}"; do
   (

--- a/github/go.mod
+++ b/github/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/bradleyfalzon/ghinstallation v0.1.2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/google/go-github/v25 v25.0.2
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0 // indirect
 )

--- a/github/go.sum
+++ b/github/go.sum
@@ -11,6 +11,8 @@ github.com/google/go-github/v25 v25.0.2 h1:MqXE7nOlIF91NJ/PXAcvS2dC+XXCDbY7RvJzj
 github.com/google/go-github/v25 v25.0.2/go.mod h1:6z5pC69qHtrPJ0sXPsj4BLnd82b+r6sLB7qcBoRZqpw=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/github/issue_comment.go
+++ b/github/issue_comment.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/google/go-github/v25/github"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -21,7 +21,7 @@ var (
 	ErrNoTrigger      = errors.New("Comment doesn't contain trigger phrase")
 )
 
-func HandleIssueComment(ice *github.IssueCommentEvent, id string) string {
+func HandleIssueComment(ice *github.IssueCommentEvent, id string) error {
 	i := ice.GetIssue()
 	c := ice.GetComment()
 
@@ -47,21 +47,25 @@ Comment body:
 	)
 
 	if err := IsTriggerComment(ice); err != nil {
-		return "Validation: " + err.Error()
+		return errors.Wrap(err, "Validation")
 	}
 
 	repo := ice.GetRepo()
 	owner := repo.GetOwner().GetLogin()
 	name := repo.GetName()
 
+	if err := Setup(); err != nil {
+		return errors.Wrap(err, "Setup")
+	}
+
 	client, err := GetInstallationClient(owner, name)
 	if err != nil {
-		return "Installation client: " + err.Error()
+		return errors.Wrap(err, "Installation client")
 	}
 
 	pr, _, err := client.PullRequests.Get(Ctx, owner, name, i.GetNumber())
 	if err != nil {
-		return "Getting PR: " + err.Error()
+		return errors.Wrap(err, "Getting PR")
 	}
 
 	fmt.Println("Processing fake PullRequestEvent")

--- a/github/issue_comment.go
+++ b/github/issue_comment.go
@@ -54,10 +54,6 @@ Comment body:
 	owner := repo.GetOwner().GetLogin()
 	name := repo.GetName()
 
-	if err := Setup(); err != nil {
-		return errors.Wrap(err, "Setup")
-	}
-
 	client, err := GetInstallationClient(owner, name)
 	if err != nil {
 		return errors.Wrap(err, "Installation client")

--- a/github/main.go
+++ b/github/main.go
@@ -32,7 +32,6 @@ var (
 	RegistratorUsername = os.Getenv("REGISTRATOR_USERNAME")
 	RegistryBranch      = os.Getenv("REGISTRY_BRANCH")
 	ContactUser         = os.Getenv("GITHUB_CONTACT_USER")
-	S3Bucket            = os.Getenv("S3_BUCKET")
 	WebhookSecret       = []byte(os.Getenv("GITHUB_WEBHOOK_SECRET"))
 
 	Ctx          = context.Background()

--- a/github/main.go
+++ b/github/main.go
@@ -79,13 +79,13 @@ func init() {
 
 	// Extract the resources into the temp directory.
 	// The reason that we have to do the extraction in the first place is that
-	// the default bundling doesn't preserve file permissions, which fudges GNUPG.
+	// the default bundling doesn't preserve file permissions, which fudges GnuPG.
 	if err := DoCmd("tar", "-xf", ResourcesTar, "-C", ResourcesDir); err != nil {
 		fmt.Println("tar:", err)
 		return
 	}
 
-	// Make GNUPG use our key.
+	// Make GnuPG use our key.
 	os.Setenv("GNUPGHOME", filepath.Join(ResourcesDir, GPGDir))
 
 	// Load the private GitHub key for our app.

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -197,6 +197,9 @@ func (ri ReleaseInfo) DoRelease(client *github.Client, pr *github.PullRequest, i
 	// Create a Git tag, only if one doesn't already exist.
 	// If a tag already exists, then there's a pretty good chance that a GitHub release also exists.
 	// However, failing there provides a much more useful error message for users.
+	// Also, we only check for 404, not any other request errors.
+	// If the request didn't go through for some reason,
+	// we can still safely skip tag creation and GitHub will tag for us when we create the release.
 	ref := "tags/" + ri.Version
 	if _, resp, _ := client.Git.GetRef(Ctx, ri.Owner, ri.Name, ref); resp.StatusCode == 404 {
 		if err = ri.CreateTag(auth); err != nil {

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -164,7 +164,6 @@ func (ri ReleaseInfo) CreateTag(auth string) error {
 	}
 
 	// Configure Git.
-	// TODO: We'll probably need to gpg.program as well.
 	if err = exec.Command("git", "-C", dir, "config", "user.name", TaggerName).Run(); err != nil {
 		return err
 	}

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -68,10 +68,6 @@ PR Body:
 		return errors.Wrap(err, "Validation")
 	}
 
-	if err := Setup(); err != nil {
-		return errors.Wrap(err, "Setup")
-	}
-
 	ri := ParseBody(PreprocessBody(pr.GetBody()))
 
 	client, err := GetInstallationClient(ri.Owner, ri.Name)

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,6 +15,8 @@ package:
 functions:
   github:
     handler: bin/github
+    layers:
+      - arn:aws:lambda:us-east-1:553035198032:layer:git:5
     events:
       - http:
           path: /webhook/github

--- a/serverless.yml
+++ b/serverless.yml
@@ -9,6 +9,8 @@ provider:
     GITHUB_CONTACT_USER: ${env:GITHUB_CONTACT_USER}
     REGISTRATOR_USERNAME: ${env:REGISTRATOR_USERNAME}
     REGISTRY_BRANCH: ${env:REGISTRY_BRANCH}
+    GIT_TAGGER_NAME: ${env:GIT_TAGGER_NAME}
+    GIT_TAGGER_EMAIL: ${env:GIT_TAGGER_EMAIL}
 package:
   exclude: [./**]
   include: [./bin/**]

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,21 +4,32 @@ provider:
   runtime: go1.x
   environment:
     GITHUB_APP_ID: ${env:GITHUB_APP_ID}
-    GITHUB_PEM_FILE: ${env:GITHUB_PEM_FILE}
     GITHUB_WEBHOOK_SECRET: ${env:GITHUB_WEBHOOK_SECRET}
     GITHUB_CONTACT_USER: ${env:GITHUB_CONTACT_USER}
     REGISTRATOR_USERNAME: ${env:REGISTRATOR_USERNAME}
     REGISTRY_BRANCH: ${env:REGISTRY_BRANCH}
     GIT_TAGGER_NAME: ${env:GIT_TAGGER_NAME}
     GIT_TAGGER_EMAIL: ${env:GIT_TAGGER_EMAIL}
+    S3_BUCKET: ${env:S3_BUCKET}
+  iamRoleStatements:
+    - Effect: Allow
+      Action:
+        - s3:ListBucket
+        - s3:GetObject
+      Resource:
+        - arn:aws:s3:::${env:S3_BUCKET}
+        - arn:aws:s3:::${env:S3_BUCKET}/*
 package:
-  exclude: [./**]
-  include: [./bin/**]
+  exclude:
+    - ./**
+  include:
+    - ./bin/**
 functions:
   github:
     handler: bin/github
+    timeout: 30
     layers:
-      - arn:aws:lambda:us-east-1:553035198032:layer:git:5
+      - arn:aws:lambda:us-east-1:744348701589:layer:bash:5
     events:
       - http:
           path: /webhook/github

--- a/serverless.yml
+++ b/serverless.yml
@@ -10,15 +10,6 @@ provider:
     REGISTRY_BRANCH: ${env:REGISTRY_BRANCH}
     GIT_TAGGER_NAME: ${env:GIT_TAGGER_NAME}
     GIT_TAGGER_EMAIL: ${env:GIT_TAGGER_EMAIL}
-    S3_BUCKET: ${env:S3_BUCKET}
-  iamRoleStatements:
-    - Effect: Allow
-      Action:
-        - s3:ListBucket
-        - s3:GetObject
-      Resource:
-        - arn:aws:s3:::${env:S3_BUCKET}
-        - arn:aws:s3:::${env:S3_BUCKET}/*
 package:
   exclude:
     - ./**

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,7 +29,7 @@ functions:
     handler: bin/github
     timeout: 30
     layers:
-      - arn:aws:lambda:us-east-1:744348701589:layer:bash:5
+      - arn:aws:lambda:us-east-1:553035198032:layer:git:5
     events:
       - http:
           path: /webhook/github


### PR DESCRIPTION
Closes #11 

Instead of creating tags with the GitHub API, we can use the Git CLI instead, which allows us to sign our tags with a GPG key.

This should work in theory but I have not yet tested it at all.

