### PR TITLE
Generate changelog from commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ This is also useful when TagBot reports an error.
 To include the tag command in a comment without actually triggering a release, include `TagBot ignore` in your comment.
 This should be useful for registry maintainers who want to make recommendations without modifying another repository.
 
+### Patch Notes
+
+TagBot allows you to write your patch notes in the same place that you trigger Registrator, but you don't have to if you're feeling lazy.
+When patch notes are provided, they are copied into both the Git tag message and the GitHub release.
+If you do not write any notes, a changelog is automatically generated from your repository's commit log.
+This will appear in the GitHub release, and a link to that release will appear in the Git tag message.
+
 For more information on what TagBot is and isn't, please see the [announcement].
 
 [app-img]: https://img.shields.io/badge/GitHub%20App-install-blue.svg

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -327,7 +327,7 @@ outer:
 	sort.Slice(commits, func(i, j int) bool {
 		return commits[i].GetCommit().GetMessage() < commits[j].GetCommit().GetMessage()
 	})
-	body := "Changelog:\n\n"
+	body := "**Changelog**\n\n"
 	prs := []string{}
 	for _, c := range commits {
 		lines := strings.Split(c.GetCommit().GetMessage(), "\n")
@@ -340,7 +340,7 @@ outer:
 		}
 	}
 	if len(prs) > 0 {
-		body += "\nMerged PRs:\n\n"
+		body += "\n**Merged PRs**\n\n"
 		for _, pr := range prs {
 			body += pr
 		}

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/google/go-github/v25/github"
@@ -22,11 +23,15 @@ var (
 	ErrVersionMatch   = errors.New("No version regex match")
 	ErrCommitMatch    = errors.New("No commit regex match")
 	ErrNoAuthHeader   = errors.New("Authentication header was not set")
+	ErrNoCommits      = errors.New("No commits were found")
+	ErrNotEnoughTags  = errors.New("Not enough tags were found")
+	ErrNoVersion      = errors.New("Version was not found in Project.toml")
 
 	RepoRegex       = regexp.MustCompile(`Repository:.*github.com/(.*)/(.*)`)
 	VersionRegex    = regexp.MustCompile(`Version:\s*(v.*)`)
 	CommitRegex     = regexp.MustCompile(`Commit:\s*(.*)`)
 	PatchNotesRegex = regexp.MustCompile(`(?s)<!-- BEGIN PATCH NOTES -->(.*)<!-- END PATCH NOTES -->`)
+	MergedPRRegex   = regexp.MustCompile(`Merge pull request #(\d+)`)
 )
 
 // ReleaseInfo contains the information needed to create a GitHub release.
@@ -169,11 +174,14 @@ func (ri ReleaseInfo) CreateTag(auth string) error {
 	}
 
 	// Create and push the tag.
-	args := []string{"-C", dir, "tag", ri.Version, "-s"}
-	if ri.PatchNotes != "" {
-		args = append(args, "-m", ri.PatchNotes)
+	msg := ri.PatchNotes
+	if msg == "" {
+		msg = fmt.Sprintf(
+			"See https://github.com/%s/%s/releases/tag/%s for patch notes",
+			ri.Owner, ri.Name, ri.Version,
+		)
 	}
-	if err = DoCmd("git", args...); err != nil {
+	if err = DoCmd("git", "-C", dir, "tag", ri.Version, "-s", "-m", msg); err != nil {
 		return errors.Wrap(err, "git tag")
 	}
 	if err = DoCmd("git", "-C", dir, "push", "origin", "--tags"); err != nil {
@@ -226,15 +234,21 @@ func (ri ReleaseInfo) DoRelease(client *github.Client, pr *github.PullRequest, i
 	}
 
 	// Create a GitHub release associated with the tag.
-	var body *string
-	if ri.PatchNotes != "" {
-		body = github.String(ri.PatchNotes)
-	}
 	rel := &github.RepositoryRelease{
 		TagName:         github.String(ri.Version),
 		Name:            github.String(ri.Version),
 		TargetCommitish: github.String(target),
-		Body:            body,
+	}
+	if ri.PatchNotes == "" {
+		rel.Body = github.String(ri.PatchNotes)
+	} else {
+		body, err := ri.Changelog(client)
+		if err == nil {
+			rel.Body = github.String(body)
+		} else {
+			fmt.Println("Changelog:", err)
+		}
+
 	}
 	if rel, _, err = client.Repositories.CreateRelease(Ctx, ri.Owner, ri.Name, rel); err != nil {
 		err = errors.Wrap(err, "Creating release")
@@ -245,6 +259,95 @@ func (ri ReleaseInfo) DoRelease(client *github.Client, pr *github.PullRequest, i
 	MakeSuccessComment(pr, id, rel)
 	fmt.Printf("Created release %s for %s/%s at %s\n", ri.Version, ri.Owner, ri.Name, ri.Commit)
 	return nil
+}
+
+// Changelog generates a changelog based on commits.
+func (ri ReleaseInfo) Changelog(client *github.Client) (string, error) {
+	// Collect all the tags.
+	opts := &github.ListOptions{}
+	tags := []*github.RepositoryTag{}
+	for {
+		ts, resp, err := client.Repositories.ListTags(Ctx, ri.Owner, ri.Name, opts)
+		if err != nil {
+			return "", errors.Wrap(err, "List tags")
+		}
+
+		for _, t := range ts {
+			tags = append(tags, t)
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	if len(tags) == 0 {
+		return "", ErrNotEnoughTags
+	}
+
+	// Get the highest tag that is not the new release.
+	sort.Slice(tags, func(i, j int) bool {
+		return tags[i].GetName() < tags[j].GetName()
+	})
+	lastTag := tags[len(tags)-1]
+	if lastTag.GetName() == ri.Version {
+		if len(tags) < 2 {
+			return "", ErrNotEnoughTags
+		}
+		lastTag = tags[len(tags)-2]
+	}
+
+	// Collect all the commits since the previous tag.
+	commits := []*github.RepositoryCommit{}
+	cOpts := &github.CommitsListOptions{SHA: ri.Commit}
+outer:
+	for {
+		cs, resp, err := client.Repositories.ListCommits(Ctx, ri.Owner, ri.Name, cOpts)
+		if err != nil {
+			return "", errors.Wrap(err, "List commits")
+		}
+
+		for _, c := range cs {
+			if c.GetSHA() == lastTag.GetCommit().GetSHA() {
+				break outer
+			}
+			commits = append(commits, c)
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		cOpts.Page = resp.NextPage
+	}
+	if len(commits) == 0 {
+		return "", ErrNoCommits
+	}
+
+	// Build up the message.
+	sort.Slice(commits, func(i, j int) bool {
+		return commits[i].GetCommit().GetMessage() < commits[j].GetCommit().GetMessage()
+	})
+	body := "Changelog:\n\n"
+	prs := []string{}
+	for _, c := range commits {
+		lines := strings.Split(c.GetCommit().GetMessage(), "\n")
+		msg := strings.TrimSpace(lines[0])
+		sha := c.GetSHA()[:7]
+		if match := MergedPRRegex.FindStringSubmatch(msg); match != nil {
+			prs = append(prs, fmt.Sprintf("- #%s (%s)\n", match[1], sha))
+		} else {
+			body += fmt.Sprintf("- %s (%s)\n", msg, sha)
+		}
+	}
+	if len(prs) > 0 {
+		body += "\nMerged PRs:\n\n"
+		for _, pr := range prs {
+			body += pr
+		}
+	}
+	body += "\nThis changelog was automatically generated and might contain inaccuracies."
+
+	return body, nil
 }
 
 // MakeSuccessComment adds a comment to the PR indicating success.

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -240,15 +240,14 @@ func (ri ReleaseInfo) DoRelease(client *github.Client, pr *github.PullRequest, i
 		TargetCommitish: github.String(target),
 	}
 	if ri.PatchNotes == "" {
-		rel.Body = github.String(ri.PatchNotes)
-	} else {
 		body, err := ri.Changelog(client)
 		if err == nil {
 			rel.Body = github.String(body)
 		} else {
 			fmt.Println("Changelog:", err)
 		}
-
+	} else {
+		rel.Body = github.String(ri.PatchNotes)
 	}
 	if rel, _, err = client.Repositories.CreateRelease(Ctx, ri.Owner, ri.Name, rel); err != nil {
 		err = errors.Wrap(err, "Creating release")
@@ -327,7 +326,7 @@ outer:
 	sort.Slice(commits, func(i, j int) bool {
 		return commits[i].GetCommit().GetMessage() < commits[j].GetCommit().GetMessage()
 	})
-	body := "**Changelog**\n\n"
+	body := "**Commits**\n\n"
 	prs := []string{}
 	for _, c := range commits {
 		lines := strings.Split(c.GetCommit().GetMessage(), "\n")

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -344,7 +344,7 @@ outer:
 			body += pr
 		}
 	}
-	body += "\nThis changelog was automatically generated and might contain inaccuracies."
+	body += "\nThis changelog was automatically generated, and might contain inaccuracies."
 
 	return body, nil
 }


### PR DESCRIPTION
An example for PkgTemplates:

```
**Changelog**


- Add /dev/ to gitignore (e867296)
- Add EUPL-1.2+ (EN) license (3925d26)
- Ditch REQUIRE, add [compat] (d4f7c8f)
- Remove (EN) from EUPL full name (99793f7)
- Remove extra empty line at end of EUPL file (23cc153)
- Revert "Use METADATA-compatible UUIDs" (9662438)
- Test 1.1 (8ebb98e)
- Use correctly typed array as default assets (310f621)
- clarify `ssh` option (82abcb9)

**Merged PRs**

- #59 (beb169a)
- #63 (6f00575)
- #64 (901a0a3)
- #70 (40c22b1)
- #74 (77b55fb)
- #75 (a519916)

This changelog was automatically generated and might contain inaccuracies.
```

This is only used if the user didn't provide their own patch notes. It gets put in the GitHub release, and a URL reference to the GitHub release gets used as the Git tag message.
I haven't yet tested this live, I'll try tomorrow.

The code is also kind of ugly, it could use some cleanup.