### PR TITLE
Unquote patch notes

### DIFF
--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -133,8 +133,12 @@ func ParseBody(body string) ReleaseInfo {
 	// This one is optional, and just defaults to no notes.
 	match = PatchNotesRegex.FindStringSubmatch(body)
 	var notes string
-	if match != nil {
-		notes = strings.TrimSpace(match[1])
+	if match != nil && strings.TrimSpace(match[1]) != "" {
+		lines := strings.Split(strings.TrimSpace(match[1]), "\n")
+		for i, l := range lines {
+			lines[i] = strings.TrimSpace(l[1:])
+		}
+		notes = strings.Join(lines, "\n")
 	}
 
 	return ReleaseInfo{

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -133,12 +133,15 @@ func ParseBody(body string) ReleaseInfo {
 	// This one is optional, and just defaults to no notes.
 	match = PatchNotesRegex.FindStringSubmatch(body)
 	var notes string
-	if match != nil && strings.TrimSpace(match[1]) != "" {
-		lines := strings.Split(strings.TrimSpace(match[1]), "\n")
-		for i, l := range lines {
-			lines[i] = strings.TrimSpace(l[1:])
+	if match != nil {
+		notes = strings.TrimSpace(match[1])
+		lines := strings.Split(notes, "\n")
+		if strings.HasPrefix(lines[0], "> ") {
+			for i, l := range lines {
+				lines[i] = strings.TrimSpace(l[1:])
+			}
+			notes = strings.Join(lines, "\n")
 		}
-		notes = strings.Join(lines, "\n")
 	}
 
 	return ReleaseInfo{

--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -69,7 +69,8 @@ func TestParseBody(t *testing.T) {
 	}{
 		{makeBody("github.com/a/b", "v0.1.0", "sha", ""), ReleaseInfo{"a", "b", "v0.1.0", "sha", ""}},
 		{makeBody("https://github.com/a/b", "v0.1.0", "sha", " "), ReleaseInfo{"a", "b", "v0.1.0", "sha", ""}},
-		{makeBody("http://github.com/a/b", "v0.1.0", "sha", "notes"), ReleaseInfo{"a", "b", "v0.1.0", "sha", "notes"}},
+		{makeBody("http://github.com/a/b", "v0.1.0", "sha", "> notes"), ReleaseInfo{"a", "b", "v0.1.0", "sha", "notes"}},
+		{makeBody("http://github.com/a/b", "v0.1.0", "sha", "> foo\n> bar"), ReleaseInfo{"a", "b", "v0.1.0", "sha", "foo\nbar"}},
 	}
 
 	for i, tt := range cases {

--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -68,8 +68,9 @@ func TestParseBody(t *testing.T) {
 		out ReleaseInfo
 	}{
 		{makeBody("github.com/a/b", "v0.1.0", "sha", ""), ReleaseInfo{"a", "b", "v0.1.0", "sha", ""}},
-		{makeBody("https://github.com/a/b", "v0.1.0", "sha", " "), ReleaseInfo{"a", "b", "v0.1.0", "sha", ""}},
-		{makeBody("http://github.com/a/b", "v0.1.0", "sha", "> notes"), ReleaseInfo{"a", "b", "v0.1.0", "sha", "notes"}},
+		{makeBody("https://github.com/a/b", "v0.1.0", "sha", ""), ReleaseInfo{"a", "b", "v0.1.0", "sha", ""}},
+		{makeBody("http://github.com/a/b", "v0.1.0", "sha", " "), ReleaseInfo{"a", "b", "v0.1.0", "sha", ""}},
+		{makeBody("http://github.com/a/b", "v0.1.0", "sha", "notes"), ReleaseInfo{"a", "b", "v0.1.0", "sha", "notes"}},
 		{makeBody("http://github.com/a/b", "v0.1.0", "sha", "> foo\n> bar"), ReleaseInfo{"a", "b", "v0.1.0", "sha", "foo\nbar"}},
 	}
 


### PR DESCRIPTION
Reference: https://github.com/JuliaRegistries/General/pull/781

This doesn't actually require any coordination with Registrator, it will handle both quoted and unquoted notes, with the one exception of when the actual notes  start with "> " (presumably very rare). When Registrator is updated, I'll just assume that the notes are always quoted to make the code simpler. 