### PR TITLE
Update patch notes to release notes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ TagBot does not handle manual registrations.
 
 If you register a package before enabling TagBot, you can still have a release created retroactively.
 To trigger the release, add a comment to your merged registry PR containing the text `TagBot tag`.
-This is also useful when TagBot reports an error.  
+This is also useful when TagBot reports an error.
 To include the tag command in a comment without actually triggering a release, include `TagBot ignore` in your comment.
 This should be useful for registry maintainers who want to make recommendations without modifying another repository.
 
-### Patch Notes
+### Release Notes
 
-TagBot allows you to write your patch notes in the same place that you trigger Registrator, but you don't have to if you're feeling lazy.
-When patch notes are provided, they are copied into both the Git tag message and the GitHub release.
+TagBot allows you to write your release notes in the same place that you trigger Registrator, but you don't have to if you're feeling lazy.
+When release notes are provided, they are copied into both the Git tag message and the GitHub release.
 If you do not write any notes, a changelog is automatically generated from your repository's commit log.
 This will appear in the GitHub release, and a link to that release will appear in the Git tag message.
 

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -30,7 +30,7 @@ var (
 	RepoRegex         = regexp.MustCompile(`Repository:.*github.com/(.*)/(.*)`)
 	VersionRegex      = regexp.MustCompile(`Version:\s*(v.*)`)
 	CommitRegex       = regexp.MustCompile(`Commit:\s*(.*)`)
-	ReleaseNotesRegex = regexp.MustCompile(`(?s)<!-- BEGIN PATCH NOTES -->(.*)<!-- END PATCH NOTES -->`)
+	ReleaseNotesRegex = regexp.MustCompile(`(?s)<!-- BEGIN (?:PATCH|RELEASE) NOTES -->(.*)<!-- END (?:PATCH|RELEASE) NOTES -->`)
 	MergedPRRegex     = regexp.MustCompile(`Merge pull request #(\d+)`)
 )
 

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -27,19 +27,19 @@ var (
 	ErrNotEnoughTags  = errors.New("Not enough tags were found")
 	ErrNoVersion      = errors.New("Version was not found in Project.toml")
 
-	RepoRegex       = regexp.MustCompile(`Repository:.*github.com/(.*)/(.*)`)
-	VersionRegex    = regexp.MustCompile(`Version:\s*(v.*)`)
-	CommitRegex     = regexp.MustCompile(`Commit:\s*(.*)`)
+	RepoRegex         = regexp.MustCompile(`Repository:.*github.com/(.*)/(.*)`)
+	VersionRegex      = regexp.MustCompile(`Version:\s*(v.*)`)
+	CommitRegex       = regexp.MustCompile(`Commit:\s*(.*)`)
 	ReleaseNotesRegex = regexp.MustCompile(`(?s)<!-- BEGIN PATCH NOTES -->(.*)<!-- END PATCH NOTES -->`)
-	MergedPRRegex   = regexp.MustCompile(`Merge pull request #(\d+)`)
+	MergedPRRegex     = regexp.MustCompile(`Merge pull request #(\d+)`)
 )
 
 // ReleaseInfo contains the information needed to create a GitHub release.
 type ReleaseInfo struct {
-	Owner      string
-	Name       string
-	Version    string
-	Commit     string
+	Owner        string
+	Name         string
+	Version      string
+	Commit       string
 	ReleaseNotes string
 }
 
@@ -150,10 +150,10 @@ func ParseBody(body string) ReleaseInfo {
 	}
 
 	return ReleaseInfo{
-		Owner:      owner,
-		Name:       name,
-		Version:    version,
-		Commit:     commit,
+		Owner:        owner,
+		Name:         name,
+		Version:      version,
+		Commit:       commit,
 		ReleaseNotes: notes,
 	}
 }

--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -31,7 +31,7 @@ func makeBody(repository, version, commit, notes string) string {
 		ss = append(ss, "Commit: "+commit)
 	}
 	if notes != "" {
-		ss = append(ss, "Patch notes:", "<!-- BEGIN PATCH NOTES -->", notes, "<!-- END PATCH NOTES -->")
+		ss = append(ss, "Release notes:", "<!-- BEGIN PATCH NOTES -->", notes, "<!-- END PATCH NOTES -->")
 	}
 	return strings.TrimSpace(strings.Join(ss, "\n"))
 }

--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -31,7 +31,7 @@ func makeBody(repository, version, commit, notes string) string {
 		ss = append(ss, "Commit: "+commit)
 	}
 	if notes != "" {
-		ss = append(ss, "Release notes:", "<!-- BEGIN PATCH NOTES -->", notes, "<!-- END PATCH NOTES -->")
+		ss = append(ss, "Release notes:", "<!-- BEGIN RELEASE NOTES -->", notes, "<!-- END RELEASE NOTES -->")
 	}
 	return strings.TrimSpace(strings.Join(ss, "\n"))
 }


### PR DESCRIPTION
https://github.com/JuliaRegistries/TagBot/pull/17/files?w=1 for easier review.

I guess we should also add
```diff
diff --git a/github/pull_request.go b/github/pull_request.go
index acc6958..3550a44 100644
--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -30,7 +30,7 @@ var (
        RepoRegex       = regexp.MustCompile(`Repository:.*github.com/(.*)/(.*)`)
        VersionRegex    = regexp.MustCompile(`Version:\s*(v.*)`)
        CommitRegex     = regexp.MustCompile(`Commit:\s*(.*)`)
-       ReleaseNotesRegex = regexp.MustCompile(`(?s)<!-- BEGIN PATCH NOTES -->(.*)<!-- END PATCH NOTES -->`)
+       ReleaseNotesRegex = regexp.MustCompile(`(?s)<!-- BEGIN RELEASE NOTES -->(.*)<!-- END RELEASE NOTES -->`)
        MergedPRRegex   = regexp.MustCompile(`Merge pull request #(\d+)`)
 )
 
diff --git a/github/pull_request_test.go b/github/pull_request_test.go
index 2a78e96..cf0bc42 100644
--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -31,7 +31,7 @@ func makeBody(repository, version, commit, notes string) string {
                ss = append(ss, "Commit: "+commit)
        }
        if notes != "" {
-               ss = append(ss, "Release notes:", "<!-- BEGIN PATCH NOTES -->", notes, "<!-- END PATCH NOTES -->")
+               ss = append(ss, "Release notes:", "<!-- BEGIN RELEASE NOTES -->", notes, "<!-- END RELEASE NOTES -->")
        }
        return strings.TrimSpace(strings.Join(ss, "\n"))
 }
```
but needs to be coordinated with Registrator.

Btw, autogenerated patch notes are pretty cool!