### PR TITLE
Reintroduce support for GPG signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - run: $GITHUB_WORKSPACE/bin/publish.py
+      - run: make publish
         env:
           DOCKER_IMAGE: tagbot
           DOCKER_USERNAME: degraafc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,9 @@ jobs:
         with:
           python-version: 3.8
       - run: pip install -r requirements.txt -r requirements.dev.txt
-      - run: $GITHUB_WORKSPACE/bin/test.sh
+      - run: make test
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make test-docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.8
+FROM python:3.8-alpine
+RUN apk add git gnupg
 COPY requirements.txt /root
 RUN pip install -r /root/requirements.txt
 COPY tagbot /root/tagbot

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test test-docker publish
+
+test:
+	./bin/test.sh
+
+test-docker:
+	./bin/test-docker.sh
+
+publish:
+	./bin/publish.py

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ with:
   ssh: ${{ secrets.DEPLOY_KEY }}
 ```
 
-If you already have a deploy key and matching repository secret for Documenter, you can reuse it instead of creating a new one.
+If you already have a Base64-encoded deploy key and matching repository secret for Documenter, you can reuse it instead of creating a new one.
 
 ### Changelogs
 
@@ -124,7 +124,7 @@ It also allows you to exclude issues and pull requests from the changelog by add
 ### GPG Signing
 
 If you want to create signed tags, you can supply your own GPG private key.
-Your key can be exported with `gpg --export-secret-keys --armor <ID>`.
+Your key can be exported with `gpg --export-secret-keys --armor <ID>`, and optionally Base64-encoded.
 It must not be protected by a password.
 Create the repository secret, then use the `gpg` input:
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ The data available to you looks like this:
 You can see the default template in [`action.yml`](action.yml).
 It also allows you to exclude issues and pull requests from the changelog by adding the `changelog-skip` label to them.
 
+### GPG Signing
+
+If you want to create signed tags, you can supply your own GPG private key.
+Your key can be exported with `gpg --export-secret-keys --armor <ID>`.
+It must not be protected by a password.
+Create the repository secret, then use the `gpg` input:
+
+```yml
+with:
+  token: ${{ secrets.GITHUB_TOKEN }}
+  gpg: ${{ secrets.GPG_KEY }}
+```
+
 ### Custom Registries
 
 If you're using a custom registry, add the `registry` input:

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   ssh:
     description: SSH private key for pushing tags
     required: false
+  gpg:
+    description: GPG key for signing tags
+    required: false
   changelog:
     description: Changelog template
     required: false

--- a/bin/test-docker.sh
+++ b/bin/test-docker.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+cd $(dirname "$0")/..
+
+docker build -t tagbot:test .
+docker run --rm --mount type=bind,source=$(pwd),target=/repo tagbot:test sh -c '
+  apk add gcc make musl-dev
+  pip install -r /repo/requirements.dev.txt
+  cd /repo
+  make test'

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -15,9 +15,9 @@ checked() {
 cd $(dirname "$0")/..
 
 checked pytest --cov tagbot
-checked black --check bin tagbot test
-checked flake8 bin tagbot test
+checked black --check bin stubs tagbot test
+checked flake8 bin stubs tagbot test
 # The test code monkey patches methods a lot, and mypy doesn't like that.
-checked mypy --strict bin tagbot
+checked env MYPYPATH=stubs mypy --strict bin tagbot
 
 exit "$exit"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,11 +7,5 @@ python_version = 3.8
 [mypy-github.*]
 ignore_missing_imports = True
 
-[mypy-pytest.*]
-ignore_missing_imports = True
-
-[mypy-semver.*]
-ignore_missing_imports = True
-
 [tool:pytest]
 filterwarnings = ignore::DeprecationWarning

--- a/stubs/semver.py
+++ b/stubs/semver.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class VersionInfo:
+    prerelease: str
+    build: str
+
+    def __lt__(self, other: VersionInfo) -> bool:
+        ...
+
+
+def parse_version_info(version: str) -> VersionInfo:
+    ...

--- a/tagbot/__main__.py
+++ b/tagbot/__main__.py
@@ -11,6 +11,7 @@ changelog = os.getenv("INPUT_CHANGELOG", "")
 dispatch = os.getenv("INPUT_DISPATCH", "false") == "true"
 registry_name = os.getenv("INPUT_REGISTRY", "")
 ssh = os.getenv("INPUT_SSH", "")
+gpg = os.getenv("INPUT_GPG", "")
 token = os.getenv("INPUT_TOKEN", "")
 
 if not token:
@@ -23,6 +24,7 @@ repo = Repo(
     token=token,
     changelog=changelog,
     ssh=bool(ssh),
+    gpg=bool(gpg),
 )
 versions = repo.new_versions()
 
@@ -34,9 +36,10 @@ if dispatch:
     repo.create_dispatch_event(versions)
     info("Waiting 5 minutes for any dispatch handlers")
     time.sleep(60 * 5)
-
 if ssh:
     repo.configure_ssh(ssh)
+if gpg:
+    repo.configure_gpg(gpg)
 
 for version, sha in versions.items():
     info(f"Processing version {version} ({sha})")

--- a/tagbot/git.py
+++ b/tagbot/git.py
@@ -94,9 +94,12 @@ class Git:
         """Configure a repository."""
         self.command("config", key, val)
 
-    def create_tag(self, version: str, sha: str) -> None:
+    def create_tag(self, version: str, sha: str, annotate: bool = False) -> None:
         """Create and push a Git tag."""
-        self.command("tag", version, sha)
+        args = ["tag"]
+        if annotate:
+            args.extend(["-m", version])
+        self.command(*args, version, sha)
         self.command("push", "origin", version)
 
     def fetch_branch(self, branch: str) -> bool:

--- a/tagbot/repo.py
+++ b/tagbot/repo.py
@@ -212,9 +212,10 @@ class Repo:
         target = sha
         if self._git.commit_sha_of_default() == sha:
             target = self._repo.default_branch
+        debug(f"Release {version} target: {target}")
         log = self._changelog.get(version, sha)
-        info(f"Creating release {version} at {sha} (target {target})")
         if self._ssh or self._gpg:
-            info("Manually creating a tag")
+            info(f"Manually creating tag {version}")
             self._git.create_tag(version, sha, annotate=self._gpg)
+        info(f"Creating release {version} at {sha}")
         self._repo.create_git_release(version, version, log, target_commitish=target)

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -12,8 +12,10 @@ from github.PullRequest import PullRequest
 from tagbot.repo import Repo
 
 
-def _changelog(*, repo="", registry="", token="", template="", ssh=False):
-    r = Repo(repo=repo, registry=registry, token=token, changelog=template, ssh=ssh)
+def _changelog(*, repo="", registry="", token="", template="", ssh=False, gpg=False):
+    r = Repo(
+        repo=repo, registry=registry, token=token, changelog=template, ssh=ssh, gpg=gpg
+    )
     return r._changelog
 
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -127,10 +127,12 @@ def test_config():
 
 
 def test_create_tag():
-    g = _git(command=["", ""])
+    g = _git(command="hm")
     g.create_tag("v1.2.3", "abcdef")
     calls = [call("tag", "v1.2.3", "abcdef"), call("push", "origin", "v1.2.3")]
     g.command.assert_has_calls(calls)
+    g.create_tag("v2.3.4", "abcdef", annotate=True)
+    g.command.assert_has_calls([call("tag", "-m", "v2.3.4", "v2.3.4", "abcdef")])
 
 
 def test_fetch_branch():

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -42,6 +42,12 @@ def test_registry_path():
     assert r._registry.get_contents.call_count == 2
 
 
+def test_maybe_b64():
+    r = _repo()
+    assert r._maybe_b64("foo bar") == "foo bar"
+    assert r._maybe_b64("Zm9v") == "foo"
+
+
 def test_release_exists():
     r = _repo()
     r._repo = Mock()

--- a/test/test_repo.py
+++ b/test/test_repo.py
@@ -8,8 +8,10 @@ from github import UnknownObjectException
 from tagbot.repo import Repo
 
 
-def _repo(*, repo="", registry="", token="", changelog="", ssh=False):
-    return Repo(repo=repo, registry=registry, token=token, changelog=changelog, ssh=ssh)
+def _repo(*, repo="", registry="", token="", changelog="", ssh=False, gpg=False):
+    return Repo(
+        repo=repo, registry=registry, token=token, changelog=changelog, ssh=ssh, gpg=gpg
+    )
 
 
 @patch("os.path.isfile", return_value=True)
@@ -170,6 +172,10 @@ def test_configure_ssh(run, chmod, mkstemp):
     open.return_value.write.assert_any_call("foo\n")
 
 
+def test_configure_gpg():
+    pass  # TODO
+
+
 def test_handle_release_branch():
     r = _repo()
     r._create_release_branch_pr = Mock()
@@ -207,7 +213,7 @@ def test_create_release():
     r._git.create_tag.assert_not_called()
     r._ssh = True
     r.create_release("v1.2.3", "c")
-    r._git.create_tag.assert_called_with("v1.2.3", "c")
+    r._git.create_tag.assert_called_with("v1.2.3", "c", annotate=False)
     r._repo.create_git_release.assert_called_with(
         "v1.2.3", "v1.2.3", "log", target_commitish="c",
     )


### PR DESCRIPTION
@dilumaluthge might like this :slightly_smiling_face:

I figured since we're now back to creating Git tags via CLI (#49), we might as well support this too.
There's a bit of noise in 72d6915 and 2221490, the other stuff is what's relevant.
I haven't tested this for real yet, I'll do that when I get a chance. I have a feeling something will be broken :upside_down_face:.

Edit: This should work now with 542fdb0 