### PR TITLE
Minimize repo clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No further action is required, but you may want to check out some of the availab
 - [Changelogs](#changelogs)
 - [GPG Signing](#gpg-signing)
 - [Custom Registries](#custom-registries)
+- [Lookback Period](#lookback-period)
 - [Release Branch Management](#release-branch-management)
 - [Pre-Release Hooks](#pre-release-hooks)
 
@@ -197,6 +198,20 @@ with:
   token: ${{ secrets.GITHUB_TOKEN }}
   registry: MyOrg/MyRegistry
 ```
+
+### Lookback Period
+
+By default, TagBot checks for new releases that are at most 3 days old.
+Therefore, if you only run TagBot every five days, it might miss some releases.
+To fix this, you can specify a custom number of days to look back in time with the `lookback` input:
+
+```yml
+with:
+  token: ${{ secrets.GITHUB_TOKEN }}
+  lookback: 14
+```
+
+An extra hour is always added, so if you run TagBot every 5 days, you can safely set this input to `5`.
 
 ### Release Branch Management
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Number of minutes to wait after creating a repository dispatch event
     required: false
     default: 5
+  lookback:
+    description: Number of days to look back in time for new releases
+    required: false
+    default: 3
   ssh:
     description: SSH private key for pushing tags
     required: false

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,3 +2,4 @@ black
 flake8
 mypy
 pytest-cov
+pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 Jinja2==2.10.3
 PyGithub==1.44.1
-croniter==0.3.31
 pexpect==4.8.0
 python-gnupg==0.4.5
-pyyaml==5.3
 semver==2.9.0
 toml==0.10.0

--- a/tagbot/__main__.py
+++ b/tagbot/__main__.py
@@ -14,6 +14,7 @@ changelog = os.getenv("INPUT_CHANGELOG", "")
 changelog_ignore = os.getenv("INPUT_CHANGELOG_IGNORE", "")
 dispatch = os.getenv("INPUT_DISPATCH", "false") == "true"
 dispatch_delay = os.getenv("INPUT_DISPATCH_DELAY", "")
+lookback = os.getenv("INPUT_LOOKBACK", "")
 registry_name = os.getenv("INPUT_REGISTRY", "")
 ssh = os.getenv("INPUT_SSH")
 ssh_password = os.getenv("INPUT_SSH_PASSWORD")
@@ -38,6 +39,7 @@ repo = Repo(
     changelog_ignore=ignore,
     ssh=bool(ssh),
     gpg=bool(gpg),
+    lookback=int(lookback),
 )
 
 try:

--- a/tagbot/git.py
+++ b/tagbot/git.py
@@ -1,4 +1,3 @@
-import os.path
 import subprocess
 
 from datetime import datetime
@@ -57,38 +56,8 @@ class Git:
         except Abort:
             return False
 
-    def path(self, *paths: str) -> str:
-        """Get a path relative to the repository root."""
-        return os.path.join(self._dir, *paths)
-
     def commit_sha_of_default(self) -> str:
         return self.command("rev-parse", self._default_branch)
-
-    def commit_sha_of_tree(self, tree: str) -> Optional[str]:
-        """Get the commit SHA that corresponds to a tree SHA."""
-        # We need --all in case the registered commit isn't on the default branch.
-        # The format of each line is "<commit sha> <tree sha>".
-        lines = self.command("log", "--all", "--format=%H %T").splitlines()
-        for line in lines:
-            c, t = line.split()
-            if t == tree:
-                return c
-        return None
-
-    def commit_sha_of_tag(self, version: str) -> str:
-        """Get the commit SHA that corresponds to a tag."""
-        lines = self.command("show-ref", "-d", version).splitlines()
-        # The output looks like this: <sha> refs/tags/<version>.
-        # For lightweight tags, there's just one line which has the commit SHA.
-        # For annotaetd tags, there is a second entry where the ref has a ^{} suffix.
-        # That line's SHA is that of the commit rather than that of the tag object.
-        return max(lines, key=len).split()[0]
-
-    def invalid_tag_exists(self, version: str, sha: str) -> bool:
-        """Check whether or not an existing tag points at the wrong commit."""
-        if not self.command("tag", "--list", version):
-            return False
-        return self.commit_sha_of_tag(version) != sha
 
     def set_remote_url(self, url: str) -> None:
         """Update the origin remote URL."""

--- a/test/test_changelog.py
+++ b/test/test_changelog.py
@@ -13,7 +13,15 @@ from tagbot.repo import Repo
 
 
 def _changelog(
-    *, repo="", registry="", token="", template="", ignore=set(), ssh=False, gpg=False
+    *,
+    repo="",
+    registry="",
+    token="",
+    template="",
+    ignore=set(),
+    ssh=False,
+    gpg=False,
+    lookback=3,
 ):
     r = Repo(
         repo=repo,
@@ -23,6 +31,7 @@ def _changelog(
         changelog_ignore=ignore,
         ssh=ssh,
         gpg=gpg,
+        lookback=lookback,
     )
     return r._changelog
 

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,5 +1,3 @@
-import os.path
-
 from datetime import datetime
 from typing import List, Union
 from unittest.mock import Mock, call, patch
@@ -74,44 +72,11 @@ def test_dir(mkdtemp):
     g.command.assert_has_calls(calls)
 
 
-def test_path():
-    g = _git()
-    g._Git__dir = "dir"
-    assert g.path("foo", "bar") == os.path.join("dir", "foo", "bar")
-
-
 def test_commit_sha_of_default():
     g = _git(command="abcdef")
     g._default_branch = "branch"
     assert g.commit_sha_of_default() == "abcdef"
     g.command.assert_called_once_with("rev-parse", "branch")
-
-
-def test_commit_sha_of_tree():
-    g = _git(command="a b\n c d\n d e\n")
-    assert g.commit_sha_of_tree("b") == "a"
-    g.command.assert_called_with("log", "--all", "--format=%H %T")
-    assert g.commit_sha_of_tree("e") == "d"
-    assert g.commit_sha_of_tree("c") is None
-
-
-def test_commit_sha_of_tag():
-    g = _git(command=["a refs/tags/v1", "b refs/tags/v2\nc refs/tags/v2^{}"])
-    assert g.commit_sha_of_tag("v1") == "a"
-    g.command.assert_called_with("show-ref", "-d", "v1")
-    assert g.commit_sha_of_tag("v2") == "c"
-    g.command.assert_called_with("show-ref", "-d", "v2")
-
-
-def test_invalid_tag_exists():
-    g = _git(command=["", "v2", "v3"])
-    g.commit_sha_of_tag = Mock(side_effect=["b", "c"])
-    assert not g.invalid_tag_exists("v1", "a")
-    g.command.assert_called_with("tag", "--list", "v1")
-    g.commit_sha_of_tag.assert_not_called()
-    assert not g.invalid_tag_exists("v2", "b")
-    g.commit_sha_of_tag.assert_called_with("v2")
-    assert g.invalid_tag_exists("v2", "d")
 
 
 def test_set_remote_url():


### PR DESCRIPTION
With these changes, the repo isn't cloned if there are no new versions. 

I'm currently looking at eliminating the clone for "new" releases that have already been handled by TagBot, but it's a bit tougher.
