### PR TITLE
Reorganize the README. Move personal access tokens (PATs) to the "Advanced Configuration Options" section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ We highly recommend that you use an SSH deploy key instead of a personal access 
 
 Please keep in mind that there are security concerns with using a PAT.
 For example, a PAT has access to all of your repositories.
-To reduce the consequences of a secret being leaked, we recommend that you instead use an [SSH deploy key](#ss-deploy-keys) that only has permissions for a single repository.
+To reduce the consequences of a secret being leaked, we recommend that you instead use an [SSH deploy key](#ssh-deploy-keys) that only has permissions for a single repository.
 
 
 To use a PAT:

--- a/README.md
+++ b/README.md
@@ -30,38 +30,33 @@ jobs:
 No further action is required on your part.
 When you add a new release to a registry with Registrator, TagBot will create a GitHub release on your package's repository.
 
-You may, however, want to customize the behaviour via the available configuration options:
+You may, however, want to customize the behaviour via the available configuration options.
 
-- [Personal Access Tokens](#personal-access-tokens)
-- [SSH Deploy Keys](#ssh-deploy-keys)
-- [Changelogs](#changelogs)
-- [GPG Signing](#gpg-signing)
-- [Custom Registries](#custom-registries)
-- [Lookback Period](#lookback-period)
-- [Release Branch Management](#release-branch-management)
-- [Pre-Release Hooks](#pre-release-hooks)
+For example, if you use GitHub Actions to build the documentation for your package, you will find that with the default TagBot configuration, your documentation build is not triggered when a new tag is created.
+In this case, you will need to use [SSH Deploy Keys](#ssh-deploy-keys).
 
-### Personal Access Tokens
+Read on for a full description of all of the available configuration options.
 
-It's sometimes better to use a GitHub personal access token instead of the default `secrets.GITHUB_TOKEN`.
-The most notable reason is that the default token does not have permission to trigger events for other GitHub Actions, such as documentation builds for new tags.
-To use a personal access token:
+## Table of Contents
 
-- Create a token by following the instructions [here](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token).
-- Create a repository secret by following the instructions [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets).
-  Use whatever you like as the name, such as `TAGBOT_PAT`.
-  Use the new personal access token as the value.
-- Replace the `token` input's value with the name of your secret, like so:
+- Basic Configuration Options:
+  - [SSH Deploy Keys](#ssh-deploy-keys)
+  - [Changelogs](#changelogs)
+  - [Custom Registries](#custom-registries)  
+- Advanced Configuration Options:
+  - [GPG Signing](#gpg-signing)
+  - [Lookback Period](#lookback-period)
+  - [Personal Access Tokens (PATs)](#personal-access-tokens-pats)
+  - [Pre-Release Hooks](#pre-release-hooks)
+  - [Release Branch Management](#release-branch-management)
 
-```yml
-with:
-  token: ${{ secrets.TAGBOT_PAT }}
-```
+## Basic Configuration Options
 
 ### SSH Deploy Keys
 
-Using personal access tokens works around the default token's limitations, but they have access to all of your repositories.
-To reduce the consequences of a secret being leaked, you can instead use an SSH deploy key that only has permissions for a single repository.
+Sometimes, instead of using the default `secrets.GITHUB_TOKEN`, it is better to use an SSH deploy key.
+The most notable reason is that the default token does not have permission to trigger events for other GitHub Actions, such as documentation builds for new tags.
+
 To use an SSH deploy key:
 
 - Create an SSH key and add it to your repository by following the instructions [here](https://developer.github.com/v3/guides/managing-deploy-keys/#setup-2).
@@ -171,6 +166,18 @@ with:
 
 White-space, case, dashes, and underscores are ignored when comparing labels.
 
+### Custom Registries
+
+If you're using a custom registry, add the `registry` input:
+
+```yml
+with:
+  token: ${{ secrets.GITHUB_TOKEN }}
+  registry: MyOrg/MyRegistry
+```
+
+## Advanced Configuration Options
+
 ### GPG Signing
 
 If you want to create signed tags, you can supply your own GPG private key.
@@ -192,16 +199,6 @@ with:
   gpg_password: ${{ secrets.GPG_PASSWORD }}
 ```
 
-### Custom Registries
-
-If you're using a custom registry, add the `registry` input:
-
-```yml
-with:
-  token: ${{ secrets.GITHUB_TOKEN }}
-  registry: MyOrg/MyRegistry
-```
-
 ### Lookback Period
 
 By default, TagBot checks for new releases that are at most 3 days old.
@@ -216,20 +213,31 @@ with:
 
 An extra hour is always added, so if you run TagBot every 5 days, you can safely set this input to `5`.
 
-### Release Branch Management
+### Personal Access Tokens (PATs)
 
-If you're using [PkgDev](https://github.com/JuliaLang/PkgDev.jl) to release your packages, TagBot can manage the merging and deletion of the release branches that it creates.
-To enable this feature, use the `branches` input:
+We highly recommend that you use an SSH deploy key instead of a personal access token (PAT).
+
+Please keep in mind that there are security concerns with using a PAT.
+For example, a PAT has access to all of your repositories.
+To reduce the consequences of a secret being leaked, we recommend that you instead use an [SSH deploy key](#ss-deploy-keys) that only has permissions for a single repository.
+
+
+To use a PAT:
+
+- Create a PAT by following the instructions [here](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token).
+- Create a repository secret by following the instructions [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets).
+  Use whatever you like as the name, such as `TAGBOT_PAT`.
+  Use the new PAT as the value.
+- Replace the `token` input's value with the name of your secret, like so:
 
 ```yml
 with:
-  token: ${{ secrets.GITHUB_TOKEN }}
-  branches: true
+  token: ${{ secrets.TAGBOT_PAT }}
 ```
 
 ### Pre-Release Hooks
 
-If you want to make something happen just before releases are created, for example creating annotated, GPG-signed tags, you can do so with the `dispatch` input:
+If you want to make something happen just before releases are created, you can do so with the `dispatch` input:
 
 ```yml
 with:
@@ -260,4 +268,15 @@ with:
 Avoid setting a delay longer than the interval between TagBot runs, since your dispatch event will probably be triggered multiple times and the same release will also be attempted more than once.
 
 To use this feature, you must provide your own personal access token.
-For more details, see [Personal Access Tokens](#personal-access-tokens).
+For more details, see [Personal Access Tokens (PATs)](#personal-access-tokens-pats).
+
+### Release Branch Management
+
+If you're using [PkgDev](https://github.com/JuliaLang/PkgDev.jl) to release your packages, TagBot can manage the merging and deletion of the release branches that it creates.
+To enable this feature, use the `branches` input:
+
+```yml
+with:
+  token: ${{ secrets.GITHUB_TOKEN }}
+  branches: true
+```


### PR DESCRIPTION
We should not be recommended the use of personal access tokens (PATs) as a first resort.

The fact that PATs have access to all of your repos is a huge security problem.

SSH deploy keys are far more secure and should be the go-to option.

Really, the only reason anyone should use PATs for TagBot is if they **absolutely need** to use the pre-release hook functionality.

So this PR:
- Moves the PAT stuff to the bottom of the README
- Makes it clear that SSH deploy keys are the best option
- Explain that if you really do need to use PATs, you should create a bot user account, not your main user account.