### PR TITLE
Added option to pass client id and secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The data available to you looks like this:
       "author": {
         "name": "Real Name",
         "url": "https://github.com/username",
-        "username" "their login"
+        "username": "their login"
       },
       "body": "issue body",
       "labels": ["label1", "label2"],

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -15,7 +15,17 @@ from datetime import datetime, timedelta
 from stat import S_IREAD, S_IWRITE, S_IEXEC
 from subprocess import DEVNULL
 from tempfile import mkdtemp, mkstemp
-from typing import Dict, List, Mapping, MutableMapping, Optional, TypeVar, Union, cast
+from typing import (
+    Dict,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+    Any,
+)
 from urllib.parse import urlparse
 
 from github import Github, GithubException, UnknownObjectException
@@ -46,7 +56,7 @@ class Repo:
         ssh: bool,
         gpg: bool,
         lookback: int,
-        github_kwargs: Optional[Dict[str, object]] = None,
+        github_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         if github_kwargs is None:
             github_kwargs = dict()

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -15,17 +15,7 @@ from datetime import datetime, timedelta
 from stat import S_IREAD, S_IWRITE, S_IEXEC
 from subprocess import DEVNULL
 from tempfile import mkdtemp, mkstemp
-from typing import (
-    Dict,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-    Any,
-)
+from typing import Dict, List, Mapping, MutableMapping, Optional, TypeVar, Union, cast
 from urllib.parse import urlparse
 
 from github import Github, GithubException, UnknownObjectException

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -57,8 +57,8 @@ class Repo:
         self._gh_url = github
         self._gh_api = github_api
         self._gh = Github(
-            token, base_url=self._gh_api, per_page=100, **github_kwargs
-        )  # type: ignore
+            token, base_url=self._gh_api, per_page=100, **github_kwargs  # type: ignore
+        )
         self._repo = self._gh.get_repo(repo, lazy=True)
         self._registry = self._gh.get_repo(registry, lazy=True)
         self._token = token

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -56,7 +56,7 @@ class Repo:
         ssh: bool,
         gpg: bool,
         lookback: int,
-        github_kwargs: Dict[str, Any] = None,
+        github_kwargs: Optional[Dict[str, Any]] = None,
     ) -> None:
         if github_kwargs is None:
             github_kwargs = dict()

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -56,7 +56,9 @@ class Repo:
             github_api = f"https://{github_api}"
         self._gh_url = github
         self._gh_api = github_api
-        self._gh = Github(token, base_url=self._gh_api, per_page=100, **github_kwargs)  # type: ignore
+        self._gh = Github(
+            token, base_url=self._gh_api, per_page=100, **github_kwargs
+        )  # type: ignore
         self._repo = self._gh.get_repo(repo, lazy=True)
         self._registry = self._gh.get_repo(registry, lazy=True)
         self._token = token

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -15,7 +15,17 @@ from datetime import datetime, timedelta
 from stat import S_IREAD, S_IWRITE, S_IEXEC
 from subprocess import DEVNULL
 from tempfile import mkdtemp, mkstemp
-from typing import Dict, List, Mapping, MutableMapping, Optional, TypeVar, Union, cast
+from typing import (
+    Dict,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+    Any,
+)
 from urllib.parse import urlparse
 
 from github import Github, GithubException, UnknownObjectException
@@ -46,14 +56,17 @@ class Repo:
         ssh: bool,
         gpg: bool,
         lookback: int,
+        github_kwargs: Dict[str, Any] = None,
     ) -> None:
+        if github_kwargs is None:
+            github_kwargs = dict()
         if not urlparse(github).scheme:
             github = f"https://{github}"
         if not urlparse(github_api).scheme:
             github_api = f"https://{github_api}"
         self._gh_url = github
         self._gh_api = github_api
-        self._gh = Github(token, base_url=self._gh_api, per_page=100)
+        self._gh = Github(token, base_url=self._gh_api, per_page=100, **github_kwargs)
         self._repo = self._gh.get_repo(repo, lazy=True)
         self._registry = self._gh.get_repo(registry, lazy=True)
         self._token = token

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -56,7 +56,7 @@ class Repo:
         ssh: bool,
         gpg: bool,
         lookback: int,
-        github_kwargs: Optional[Dict[str, Any]] = None,
+        github_kwargs: Optional[Dict[str, object]] = None,
     ) -> None:
         if github_kwargs is None:
             github_kwargs = dict()

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -15,17 +15,7 @@ from datetime import datetime, timedelta
 from stat import S_IREAD, S_IWRITE, S_IEXEC
 from subprocess import DEVNULL
 from tempfile import mkdtemp, mkstemp
-from typing import (
-    Dict,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-    Any,
-)
+from typing import Dict, List, Mapping, MutableMapping, Optional, TypeVar, Union, cast
 from urllib.parse import urlparse
 
 from github import Github, GithubException, UnknownObjectException
@@ -56,7 +46,7 @@ class Repo:
         ssh: bool,
         gpg: bool,
         lookback: int,
-        github_kwargs: Optional[Dict[str, Any]] = None,
+        github_kwargs: Optional[Dict[str, object]] = None,
     ) -> None:
         if github_kwargs is None:
             github_kwargs = {}
@@ -66,7 +56,7 @@ class Repo:
             github_api = f"https://{github_api}"
         self._gh_url = github
         self._gh_api = github_api
-        self._gh = Github(token, base_url=self._gh_api, per_page=100, **github_kwargs)
+        self._gh = Github(token, base_url=self._gh_api, per_page=100, **github_kwargs)  # type: ignore
         self._repo = self._gh.get_repo(repo, lazy=True)
         self._registry = self._gh.get_repo(registry, lazy=True)
         self._token = token


### PR DESCRIPTION
I think for GitHub Action is is not needed, but if someone needs to run it otherwise, it is very useful.
If they are not present, they are set to None which is default value.