### PR TITLE
Add ssh secrets for Documenter to script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}    # recommended if you're using Documenter to build and host documentation
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
 ```
 
 No further action is required on your part.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}    # recommended if you're using Documenter to build and host documentation
 ```
 
 No further action is required on your part.


### PR DESCRIPTION
Many of us are too hasty and don't read the fine print as often as we should. Would making this "the default" hurt anything?