### PR TITLE
Add the "workflow_dispatch" trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ name: TagBot
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_dispatch:
 jobs:
   TagBot:
     runs-on: ubuntu-latest

--- a/example.yml
+++ b/example.yml
@@ -2,6 +2,7 @@ name: TagBot
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_dispatch:
 jobs:
   TagBot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
People often ask if they can manually trigger TagBot instead of waiting for the next daily run. They can now easily do so with the `workflow_dispatch` trigger.

cc: @christopher-dG 