### PR TITLE
Try to get commit of version from registry PR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "tagbot"
-version = "1.11.0"
+version = "1.11.1"
 description = "Creates tags, releases, and changelogs for your Julia packages when they're registered"
-authors = ["Chris de Graaf <chrisadegraaf@gmail.com>"]
+authors = ["Chris de Graaf <me@cdg.dev>"]
 license = "MIT"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Closes #161 

So now instead of solely relying on the Git history and taking whatever commit happens to come first that also matches the required tree SHA, the first commit that's tried is the one that Registrator was triggered on (which should almost always be a valid commit for the required tree SHA). 

