### PR TITLE
Add branch input to set preferred release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Read on for a full description of all of the available configuration options.
   - [Lookback Period](#lookback-period)
   - [Personal Access Tokens (PATs)](#personal-access-tokens-pats)
   - [Pre-Release Hooks](#pre-release-hooks)
+  - [Release Branch Selection](#release-branch-selection)
   - [Release Branch Management](#release-branch-management)
 - [Local Usage](#local-usage)
 
@@ -298,6 +299,18 @@ Avoid setting a delay longer than the interval between TagBot runs, since your d
 
 To use this feature, you must provide your own personal access token.
 For more details, see [Personal Access Tokens (PATs)](#personal-access-tokens-pats).
+
+### Release Branch Selection
+
+If you use a non-standard Git workflow where your default branch is not the main development branch, you may want to set the `branch` input to the name of your preferred release branch:
+
+```yml
+with:
+  token: ${{ secrets.GITHUB_TOKEN }}
+  branch: release
+```
+
+The branch you set will be the first one searched for a commit to tag, and releases will be anchored to that branch when possible.
 
 ### Release Branch Management
 

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,9 @@ inputs:
     description: Git email
     required: false
     default: 41898282+github-actions[bot]@users.noreply.github.com
+  branch:
+    description: Branch to create releases against when possible
+    required: false
   changelog:
     description: Changelog template
     required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tagbot"
-version = "1.11.1"
+version = "1.12.0"
 description = "Creates tags, releases, and changelogs for your Julia packages when they're registered"
 authors = ["Chris de Graaf <me@cdg.dev>"]
 license = "MIT"

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -29,6 +29,7 @@ gpg_password = os.getenv("INPUT_GPG_PASSWORD")
 user = os.getenv("INPUT_USER", "")
 email = os.getenv("INPUT_EMAIL", "")
 token = os.getenv("INPUT_TOKEN")
+branch = os.getenv("INPUT_BRANCH")
 
 if not token:
     logger.error("No GitHub API token supplied")
@@ -53,6 +54,7 @@ try:
         user=user,
         email=email,
         lookback=int(lookback),
+        branch=branch,
     )
 
     if not repo.is_registered():

--- a/tagbot/action/git.py
+++ b/tagbot/action/git.py
@@ -87,10 +87,6 @@ class Git:
                 return c
         return None
 
-    def commit_sha_of_default(self) -> str:
-        """Get the commit SHA of the default branch."""
-        return self.command("rev-parse", self._default_branch)
-
     def set_remote_url(self, url: str) -> None:
         """Update the origin remote URL."""
         self.command("remote", "set-url", "origin", url)

--- a/tagbot/local/__main__.py
+++ b/tagbot/local/__main__.py
@@ -47,6 +47,7 @@ repo = Repo(
     user=USER,
     email=EMAIL,
     lookback=0,
+    branch=None,
 )
 
 version = args.version if args.version.startswith("v") else "v" + args.version

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -26,6 +26,7 @@ def _changelog(*, template="", ignore=set()):
         user="",
         email="",
         lookback=3,
+        branch=None,
     )
     return r._changelog
 

--- a/test/action/test_git.py
+++ b/test/action/test_git.py
@@ -81,13 +81,6 @@ def test_commit_sha_of_tree():
     assert g.commit_sha_of_tree("c") is None
 
 
-def test_commit_sha_of_default():
-    g = _git(command="abcdef")
-    g._Git__default_branch = "branch"
-    assert g.commit_sha_of_default() == "abcdef"
-    g.command.assert_called_once_with("rev-parse", "branch")
-
-
 def test_set_remote_url():
     g = _git(command="hi")
     g.set_remote_url("url")


### PR DESCRIPTION
Closes #163; I think this + #169 finishes the saga of #159, #161, and #163.

cc @dehann @Paveloom

If you set `branch`, then that branch is searched first before any other branches for a commit that matches the required tree SHA. Additionally, when the commit we're tagging is at the tip of that branch, the GitHub release will display the number of commits to the chosen branch since the release, instead of commits to the default branch.
Nothing changes for people who do not opt in to this feature.