### PR TITLE
Handle missing user in issues/pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The data available to you looks like this:
       },
       "body": "issue body",
       "labels": ["label1", "label2"],
-      "merger": {"same format as": "issue author"},
+      "closer": {"same format as": "issue author but sometimes null"},
       "number": 123,
       "title": "issue title",
       "url": "https://github.com/Owner/Repo/issues/123"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tagbot"
-version = "1.12.0"
+version = "1.12.1"
 description = "Creates tags, releases, and changelogs for your Julia packages when they're registered"
 authors = ["Chris de Graaf <me@cdg.dev>"]
 license = "MIT"

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -118,13 +118,15 @@ class Changelog:
         logger.debug("No custom release notes were found")
         return None
 
-    def _format_user(self, user: NamedUser) -> Dict[str, object]:
+    def _format_user(self, user: Optional[NamedUser]) -> Dict[str, object]:
         """Format a user for the template."""
-        return {
-            "name": user.name or user.login,
-            "url": user.html_url,
-            "username": user.login,
-        }
+        if user:
+            return {
+                "name": user.name or user.login,
+                "url": user.html_url,
+                "username": user.login,
+            }
+        return {}
 
     def _format_issue(self, issue: Issue) -> Dict[str, object]:
         """Format an issue for the template."""

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -115,6 +115,7 @@ def test_format_user():
     m = Mock(html_url="url", login="username")
     m.name = "Name"
     assert c._format_user(m) == {"name": "Name", "url": "url", "username": "username"}
+    assert c._format_user(None) == {}
 
 
 def test_format_issue_pull():


### PR DESCRIPTION
This only happens rarely (when the closer has since deleted their account), but it breaks everything.