### PR TITLE
Try loading inputs from workflow dispatch inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ To reduce the consequences of a secret being leaked, we recommend that you inste
 To use a PAT:
 
 - Create a PAT by following the instructions [here](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token).
+  Make sure that it has the `repo` scope.
 - Create a repository secret by following the instructions [here](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets).
   Use whatever you like as the name, such as `TAGBOT_PAT`.
   Use the new PAT as the value.
@@ -354,6 +355,7 @@ $ docker run --rm degraafc/tagbot python -m tagbot.local \
 ```
 
 Only the `repo`, `version`, and `token` options are required, and you will be prompted if you don't provide them.
+For instructions on how to obtain a token, see [Personal Access Tokens (PATs)](#personal-access-tokens-pats).
 
 You can also run the code outside of Docker, but you'll just need to install [Poetry](https://python-poetry.org) first, and ensure that you have Python 3.8.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tagbot"
-version = "1.12.2"
+version = "1.12.3"
 description = "Creates tags, releases, and changelogs for your Julia packages when they're registered"
 authors = ["Chris de Graaf <me@cdg.dev>"]
 license = "MIT"

--- a/tagbot/__init__.py
+++ b/tagbot/__init__.py
@@ -1,6 +1,8 @@
 import os
 import sys
+import traceback
 
+from io import StringIO
 from logging import (
     DEBUG,
     INFO,
@@ -22,6 +24,12 @@ class LogFormatter(Formatter):
 
     def _fmt_actions(self, record: LogRecord) -> str:
         message = record.getMessage()
+        if record.exc_info:
+            buf = StringIO()
+            cls, inst, tb = record.exc_info
+            traceback.print_exception(cls, inst, tb, file=buf)
+            buf.seek(0)
+            message += "\n" + buf.read()
         if record.levelno == INFO:
             return message
         if record.levelno == DEBUG:

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -24,7 +24,8 @@ def get_input(key: str, default: str = "") -> str:
         with open(os.environ["GITHUB_EVENT_PATH"]) as f:
             event = json.load(f)
         INPUTS = event.get("inputs", {})
-    return INPUTS.get(key.lower(), default)
+    val = INPUTS.get(key.lower(), default)
+    return val or default
 
 
 try:

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -17,7 +17,7 @@ INPUTS: Optional[Dict[str, str]] = None
 def get_input(key: str, default: str = "") -> str:
     """Get an input from the environment, or from a workflow input if it's set."""
     global INPUTS
-    default = os.getenv(key.upper().replace("-", "_"), default)
+    default = os.getenv(f"INPUT_{key.upper().replace('-', '_')}", default)
     if INPUTS is None:
         if "GITHUB_EVENT_PATH" not in os.environ:
             return default

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -24,8 +24,7 @@ def get_input(key: str, default: str = "") -> str:
         with open(os.environ["GITHUB_EVENT_PATH"]) as f:
             event = json.load(f)
         INPUTS = event.get("inputs", {})
-    val = INPUTS.get(key.lower(), default)
-    return val or default
+    return INPUTS.get(key.lower()) or default
 
 
 try:

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -16,13 +16,13 @@ INPUTS: Optional[Dict[str, str]] = None
 
 def get_input(key: str, default: str = "") -> str:
     """Get an input from the environment, or from a workflow input if it's set."""
+    global INPUTS
     default = os.getenv(key.upper().replace("-", "_"), default)
     if INPUTS is None:
         if "GITHUB_EVENT_PATH" not in os.environ:
             return default
         with open(os.environ["GITHUB_EVENT_PATH"]) as f:
             event = json.load(f)
-        global INPUTS
         INPUTS = event.get("inputs", {})
     return INPUTS.get(key.lower(), default)
 

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -5,16 +5,11 @@ import time
 
 from typing import Dict, Optional
 
-import requests
-
 from datetime import timedelta
 
 from .. import logger
 from .changelog import Changelog
 from .repo import Repo
-
-RequestException = requests.RequestException
-
 
 INPUTS: Optional[Dict[str, str]] = None
 


### PR DESCRIPTION
This allows users to add workflow dispatch inputs.
For example:

```yml
name: TagBot
on:
  issue_comment:
    types:
      - created
  workflow_dispatch:
    # LOOK AT ME!!!
    inputs:
      lookback:
        description: Number of days to look back in the registry for new versions
jobs:
  TagBot:
    # ...
```

It's implemented generically, so you can put any input there to override the default.

This needs some manual testing before merging, since errors at this stage can't always be reported properly.