### PR TITLE
Fix key decoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tagbot"
-version = "1.12.4"
+version = "1.12.5"
 description = "Creates tags, releases, and changelogs for your Julia packages when they're registered"
 authors = ["Chris de Graaf <me@cdg.dev>"]
 license = "MIT"

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -121,7 +121,11 @@ class Repo:
     def _maybe_b64(self, val: str) -> str:
         """Return a decoded value if it is Base64-encoded, or the original value."""
         try:
-            val = b64decode(val, validate=True).decode()
+            # Stripping is necessary for encoded input, since it's easy to accidentally
+            # give a repo secret an extra trailing newline. This still works for
+            # unencoded input, since any SSH/GPG key will always have newlines
+            # in the middle.
+            val = b64decode(val.strip(), validate=True).decode()
         except binascii.Error:
             pass
         return val

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -109,6 +109,7 @@ def test_maybe_b64():
     r = _repo()
     assert r._maybe_b64("foo bar") == "foo bar"
     assert r._maybe_b64("Zm9v") == "foo"
+    assert r._maybe_b64("Zm9v\n") == "foo"
 
 
 def test_create_release_branch_pr():


### PR DESCRIPTION
Holy crap, this has  been a thorn in my side for months: https://github.com/JuliaRegistries/TagBotErrorReports/issues/56

I'm not 100% sure that this will work, at least 90% though. My guess is that when copy-pasting the encoded private key from DocumenterTools, it's very easy to accidentally get the next (empty) line of the REPL output.

I can't believe I overlooked this 🤦‍♂️ 