### PR TITLE
Assume keys are plaintext if they contain "PRIVATE KEY"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tagbot"
-version = "1.12.5"
+version = "1.12.6"
 description = "Creates tags, releases, and changelogs for your Julia packages when they're registered"
 authors = ["Chris de Graaf <me@cdg.dev>"]
 license = "MIT"


### PR DESCRIPTION
I think this should be the final entry in the saga of "SSH key invalid format".

In this new approach, we stop trying to check if something is Base64 encoded, and instead check if it is already a private key. There are a few formats for SSH private keys, but they all seem to at least share the term `PRIVATE KEY`, and GPG keys also do from my own short experiments.

This solves both the common problems we had before:

- Users used to accidentally put extra newlines at the end of the encoded key (was solved by #180)
- Users used to accidentally put newlines in the middle of the encoded key, mostly due to problems with their terminal copy-paste (not solved by #180, and basically unsolvable with that approach)