### PR TITLE
Use GHCR instead of Docker Hub for image hosting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,8 @@ jobs:
       - run: pip install PyGithub semver
       - run: make publish
         env:
-          DOCKER_IMAGE: tagbot
-          DOCKER_USERNAME: degraafc
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_IMAGE: ghcr.io/juliaregistries/tagbot
+          DOCKER_USERNAME: christopher-dG
+          DOCKER_PASSWORD: ${{ secrets.GHCR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SSH_KEY: ${{ secrets.SSH_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY pyproject.toml .
 RUN poetry export -f requirements.txt -o /root/requirements.txt
 
 FROM python:3.8-alpine
+LABEL org.opencontainers.image.source https://github.com/JuliaRegistries/TagBot
 ENV PYTHONPATH /root
 RUN apk add git gnupg openssh-client
 COPY --from=builder /root/requirements.txt /root/requirements.txt

--- a/README.md
+++ b/README.md
@@ -334,8 +334,7 @@ Perhaps TagBot failed for some reason, or GitHub's service was down, or you just
 The simplest way to run TagBot manually is through Docker and the `tagbot.local` module.
 
 ```sh
-$ docker pull degraafc/tagbot
-$ docker run --rm degraafc/tagbot python -m tagbot.local --help
+$ docker run --rm ghcr.io/juliaregistries/tagbot python -m tagbot.local --help
 Usage: __main__.py [OPTIONS]
 
 Options:
@@ -348,7 +347,7 @@ Options:
   --registry TEXT    Registry to search
   --help             Show this message and exit.
 
-$ docker run --rm degraafc/tagbot python -m tagbot.local \
+$ docker run --rm ghcr.io/juliaregistries/tagbot python -m tagbot.local \
     --repo Owner/Name \
     --token <TOKEN> \
     --version v1.2.3

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: docker://degraafc/tagbot:1.12.7
+  image: docker://ghcr.io/juliaregistries/tagbot:1.12.7
 branding:
   icon: tag
   color: red

--- a/bin/publish.py
+++ b/bin/publish.py
@@ -99,8 +99,7 @@ def update_action_yml(version: VersionInfo) -> None:
     path = repo_file("action.yml")
     with open(path) as f:
         action = f.read()
-    repo = f"{DOCKER_USERNAME}/{DOCKER_IMAGE}"
-    updated = re.sub(f"{repo}:.*", f"{repo}:{version}", action, count=1)
+    updated = re.sub(f"{DOCKER_IMAGE}:.*", f"{DOCKER_IMAGE}:{version}", action, count=1)
     with open(path, "w") as f:
         f.write(updated)
 
@@ -150,7 +149,6 @@ def get_release_notes(pr: PullRequest) -> str:
 
 
 def update_docker_images() -> None:
-    repo = f"{DOCKER_USERNAME}/{DOCKER_IMAGE}"
     docker("build", "--tag", DOCKER_IMAGE, WORKSPACE)
     docker(
         "login",
@@ -160,7 +158,7 @@ def update_docker_images() -> None:
         stdin=DOCKER_PASSWORD,
     )
     for version in expand_versions(v=False):
-        tag = f"{repo}:{version}"
+        tag = f"{DOCKER_IMAGE}:{version}"
         docker("tag", DOCKER_IMAGE, tag)
         docker("push", tag)
 


### PR DESCRIPTION
Closes #186 

The existing Docker images have all been copied to GHCR, and all of the Git tags have been updated to use those new images. This is just to make it work for future versions. Gonna need to test it out manually on another repo first to make sure that the auth and stuff works.