### PR TITLE
Make the `token` input optional (with default value of `${{ github.token }}`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,8 @@ description: Creates GitHub releases for your registered Julia packages
 inputs:
   token:
     description: GitHub API token
-    required: true
+    required: false
+    default: ${{ github.token }}
   registry:
     description: Owner/name of the registry repository
     required: false

--- a/example.yml
+++ b/example.yml
@@ -11,5 +11,4 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
See also: https://github.com/JuliaRegistries/compathelper-action/issues/5

This works in composite actions (see https://github.com/JuliaRegistries/compathelper-action/blob/main/action.yml). I'm not sure about Docker actions.

@SaschaMann Any idea if this will work in a Docker action?