### PR TITLE
Users need to provide the `permissions` key in the GitHub Actions workflow file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ on:
     inputs:
       lookback:
         default: 3
+permissions:
+  contents: write
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/example.yml
+++ b/example.yml
@@ -7,6 +7,8 @@ on:
     inputs:
       lookback:
         default: 3
+permissions:
+  contents: write
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Fixes #222 
Fixes #229 