### PR TITLE
Use SSH_KEY for ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.SSH_KEY }}
 ```
 
 No further action is required on your part.


### PR DESCRIPTION
We had to do this in a couple of places for this to work reliably. 

Example: https://github.com/JuliaInterop/RCall.jl/pull/467