### PR TITLE
Support packages in subdirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,16 +377,62 @@ with:
 
 ### Subpackage Configuration
 
-If your package is not at the top-level of your repository, you should set the  `subpackage_uuid` and `subpackage_name` inputs to the uuid and name of the package (without the `.jl` suffix):
+If your package is not at the top-level of your repository, you should set the  `subdir` input:  
 
 ```yml
 with:
   token: ${{ secrets.GITHUB_TOKEN }}
-  subpackage_name: SubpackageName
-  subpackage_uuid: 6eeaa9e1-5bf4-4477-849f-dc20c0b87e53
+  subdir: path/to/SubpackageName.jl
 ```
 
-Version tags will then be prefixed with the subpackage's name: `{PACKAGE}-v{VERSION}`, e.g., `SubpackageName-v0.2.3`. (For top-level packages, the default tag is simply `v{VERSION}`.)
+Version tags will then be prefixed with the subpackage's name: `{PACKAGE}-v{VERSION}`, e.g., `SubpackageName-v0.2.3`. (For top-level packages, the default tag is simply `v{VERSION}`.) 
+
+To tag releases from a monorepo containing multiple subpackages and an optional top-level package, set up a separate step for each package you want to tag. For example, to tag all three packages in the following repository,
+
+```
+.
+├── SubpackageA.jl
+│   ├── Package.toml
+│   └── src/...
+├── path
+│   └── to
+│       └── SubpackageB.jl
+│           ├── Package.toml
+│           └── src/...
+├── Package.toml
+└── src/...
+```
+
+the action configuration should look something like
+
+```yml
+    steps:
+      - name: Tag top-level package
+        uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+      - name: Tag subpackage A
+        uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+          subdir: SubpackageA.jl
+      - name: Tag subpackage B
+        uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+          subdir: path/to/SubpackageB.jl
+```
+
+Generated tags will then be `v0.1.2` (top-level), `SubpackageA-v0.0.3`, and `SubpackageB-v2.3.1`.
 
 ## Local Usage
 
@@ -399,16 +445,15 @@ $ docker run --rm ghcr.io/juliaregistries/tagbot python -m tagbot.local --help
 Usage: __main__.py [OPTIONS]
 
 Options:
-  --repo TEXT             Repo to tag
-  --version TEXT          Version to tag
-  --token TEXT            GitHub API token
-  --github TEXT           GitHub URL
-  --github-api TEXT       GitHub API URL
-  --changelog TEXT        Changelog template
-  --registry TEXT         Registry to search
-  --subpackage_name TEXT  Subpackage in repo
-  --subpackage_uuid TEXT  Subpackage in repo
-  --help                  Show this message and exit.
+  --repo TEXT        Repo to tag
+  --version TEXT     Version to tag
+  --token TEXT       GitHub API token
+  --github TEXT      GitHub URL
+  --github-api TEXT  GitHub API URL
+  --changelog TEXT   Changelog template
+  --registry TEXT    Registry to search
+  --subdir TEXT      Subdirectory path in repo
+  --help             Show this message and exit.
 
 $ docker run --rm ghcr.io/juliaregistries/tagbot python -m tagbot.local \
     --repo Owner/Name \

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Options:
   --github-api TEXT  GitHub API URL
   --changelog TEXT   Changelog template
   --registry TEXT    Registry to search
+  --subpackage TEXT  Subpackage in repo
   --help             Show this message and exit.
 
 $ docker run --rm ghcr.io/juliaregistries/tagbot python -m tagbot.local \

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Read on for a full description of all of the available configuration options.
   - [Pre-Release Hooks](#pre-release-hooks)
   - [Release Branch Selection](#release-branch-selection)
   - [Release Branch Management](#release-branch-management)
+  - [Subpackage Configuration](#subpackage-configuration)
 - [Local Usage](#local-usage)
 
 ## Basic Configuration Options
@@ -373,6 +374,18 @@ with:
   token: ${{ secrets.GITHUB_TOKEN }}
   branches: true
 ```
+
+### Subpackage Configuration
+
+If your package is not at the top-level of your repository, you should set the `subpackage` input to the name of that package (without the `.jl` suffix):
+
+```yml
+with:
+  token: ${{ secrets.GITHUB_TOKEN }}
+  subpackage: SubpackageName
+```
+
+This will be the package searched for a commit to tag, and releases will be prefixed with that package's name: `{PACKAGE}-v{VERSION}`. 
 
 ## Local Usage
 

--- a/README.md
+++ b/README.md
@@ -434,8 +434,9 @@ the action configuration should look something like
 
 Generated tags will then be `v0.1.2` (top-level), `SubpackageA-v0.0.3`, and `SubpackageB-v2.3.1`.
 
-> **Note: Monorepo-specific changelog behavior**
-> Each subpackage will include all issues and pull requests in its changelogs, such that a single issue will be duplicated up in all of the repository's subpackages' release notes. Careful [`changelog_ignore` and/or custom changelog settings](#changelogs) on a per-subpackage basis can mitigate this duplication.  
+**:information_source: Monorepo-specific changelog behavior**
+  
+  Each subpackage will include all issues and pull requests in its changelogs, such that a single issue will be duplicated up in all of the repository's subpackages' release notes. Careful [`changelog_ignore` and/or custom changelog settings](#changelogs) on a per-subpackage basis can mitigate this duplication.  
 
 ## Local Usage
 

--- a/README.md
+++ b/README.md
@@ -434,8 +434,8 @@ the action configuration should look something like
 
 Generated tags will then be `v0.1.2` (top-level), `SubpackageA-v0.0.3`, and `SubpackageB-v2.3.1`.
 
-!!! note
-    Monorepo-specific changelog behavior is not yet implemented: each subpackage will include all issues and pull requests in its changelogs, such that a single issue will be duplicated up in all of the repository's subpackages' release notes. Careful [`changelog_ignore` and/or custom changelog settings](#changelogs) on a per-subpackage basis, can mitigate this duplication as desired.  
+> **Note: Monorepo-specific changelog behavior**
+> Each subpackage will include all issues and pull requests in its changelogs, such that a single issue will be duplicated up in all of the repository's subpackages' release notes. Careful [`changelog_ignore` and/or custom changelog settings](#changelogs) on a per-subpackage basis can mitigate this duplication.  
 
 ## Local Usage
 

--- a/README.md
+++ b/README.md
@@ -434,6 +434,9 @@ the action configuration should look something like
 
 Generated tags will then be `v0.1.2` (top-level), `SubpackageA-v0.0.3`, and `SubpackageB-v2.3.1`.
 
+!!! note
+    Monorepo-specific changelog behavior is not yet implemented: each subpackage will include all issues and pull requests in its changelogs, such that a single issue will be duplicated up in all of the repository's subpackages' release notes. Careful [`changelog_ignore` and/or custom changelog settings](#changelogs) on a per-subpackage basis, can mitigate this duplication as desired.  
+
 ## Local Usage
 
 There are some scenarios in which you want to manually run TagBot.

--- a/README.md
+++ b/README.md
@@ -377,15 +377,16 @@ with:
 
 ### Subpackage Configuration
 
-If your package is not at the top-level of your repository, you should set the `subpackage` input to the name of that package (without the `.jl` suffix):
+If your package is not at the top-level of your repository, you should set the  `subpackage_uuid` and `subpackage_name` inputs to the uuid and name of the package (without the `.jl` suffix):
 
 ```yml
 with:
   token: ${{ secrets.GITHUB_TOKEN }}
-  subpackage: SubpackageName
+  subpackage_name: SubpackageName
+  subpackage_uuid: 6eeaa9e1-5bf4-4477-849f-dc20c0b87e53
 ```
 
-This will be the package searched for a commit to tag, and releases will be prefixed with that package's name: `{PACKAGE}-v{VERSION}`. 
+Version tags will then be prefixed with the subpackage's name: `{PACKAGE}-v{VERSION}`, e.g., `SubpackageName-v0.2.3`. (For top-level packages, the default tag is simply `v{VERSION}`.)
 
 ## Local Usage
 
@@ -398,15 +399,16 @@ $ docker run --rm ghcr.io/juliaregistries/tagbot python -m tagbot.local --help
 Usage: __main__.py [OPTIONS]
 
 Options:
-  --repo TEXT        Repo to tag
-  --version TEXT     Version to tag
-  --token TEXT       GitHub API token
-  --github TEXT      GitHub URL
-  --github-api TEXT  GitHub API URL
-  --changelog TEXT   Changelog template
-  --registry TEXT    Registry to search
-  --subpackage TEXT  Subpackage in repo
-  --help             Show this message and exit.
+  --repo TEXT             Repo to tag
+  --version TEXT          Version to tag
+  --token TEXT            GitHub API token
+  --github TEXT           GitHub URL
+  --github-api TEXT       GitHub API URL
+  --changelog TEXT        Changelog template
+  --registry TEXT         Registry to search
+  --subpackage_name TEXT  Subpackage in repo
+  --subpackage_uuid TEXT  Subpackage in repo
+  --help                  Show this message and exit.
 
 $ docker run --rm ghcr.io/juliaregistries/tagbot python -m tagbot.local \
     --repo Owner/Name \

--- a/action.yml
+++ b/action.yml
@@ -63,8 +63,11 @@ inputs:
   branch:
     description: Branch to create releases against when possible
     required: false
-  subpackage:
-    description: Name of subpackage in repo if not at top level
+  subpackage_name:
+    description: Name of subpackage in repo if not at top level (omit ".jl")
+    required: false
+  subpackage_uuid:
+    description: UUID of subpackage in repo if not at top level
     required: false
   changelog:
     description: Changelog template

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,9 @@ inputs:
   branch:
     description: Branch to create releases against when possible
     required: false
+  subpackage:
+    description: Name of subpackage in repo if not at top level
+    required: false
   changelog:
     description: Changelog template
     required: false

--- a/action.yml
+++ b/action.yml
@@ -63,11 +63,8 @@ inputs:
   branch:
     description: Branch to create releases against when possible
     required: false
-  subpackage_name:
-    description: Name of subpackage in repo if not at top level (omit ".jl")
-    required: false
-  subpackage_uuid:
-    description: UUID of subpackage in repo if not at top level
+  subdir:
+    description: Subdirectory of package in repo, if not at top level
     required: false
   changelog:
     description: Changelog template

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tagbot"
-version = "1.14.1"
+version = "1.14.2"
 description = "Creates tags, releases, and changelogs for your Julia packages when they're registered"
 authors = ["Chris de Graaf <me@cdg.dev>"]
 license = "MIT"

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -90,7 +90,7 @@ try:
 
     for package_version, sha in package_versions.items():
         logger.info(f"Processing version {package_version} ({sha})")
-        if get_input("branches", "false") == "true":
+        if get_input("branches", "false") == "true": #TODO: what happens here and why?!
             repo.handle_release_branch(package_version)
         repo.create_release(package_version, sha)
 except Exception as e:

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -73,7 +73,7 @@ try:
         )
         sys.exit()
 
-    package_versions = repo.new_package_versions() #TODO: to trace
+    package_versions = repo.new_package_versions()
     if not package_versions:
         logger.info("No new versions to release")
         sys.exit()

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -72,14 +72,14 @@ try:
         )
         sys.exit()
 
-    versions = repo.new_versions()
-    if not versions:
+    package_versions = repo.new_package_versions() #TODO: to trace
+    if not package_versions:
         logger.info("No new versions to release")
         sys.exit()
 
     if get_input("dispatch", "false") == "true":
         minutes = int(get_input("dispatch_delay"))
-        repo.create_dispatch_event(versions)
+        repo.create_dispatch_event(package_versions)
         logger.info(f"Waiting {minutes} minutes for any dispatch handlers")
         time.sleep(timedelta(minutes=minutes).total_seconds())
 
@@ -88,11 +88,11 @@ try:
     if gpg:
         repo.configure_gpg(gpg, get_input("gpg_password"))
 
-    for version, sha in versions.items():
-        logger.info(f"Processing version {version} ({sha})")
+    for package_version, sha in package_versions.items():
+        logger.info(f"Processing version {package_version} ({sha})")
         if get_input("branches", "false") == "true":
-            repo.handle_release_branch(version)
-        repo.create_release(version, sha)
+            repo.handle_release_branch(package_version)
+        repo.create_release(package_version, sha)
 except Exception as e:
     try:
         repo.handle_error(e)

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -72,14 +72,14 @@ try:
         )
         sys.exit()
 
-    package_versions = repo.new_package_versions()
-    if not package_versions:
+    versions = repo.new_versions()
+    if not versions:
         logger.info("No new versions to release")
         sys.exit()
 
     if get_input("dispatch", "false") == "true":
         minutes = int(get_input("dispatch_delay"))
-        repo.create_dispatch_event(package_versions)
+        repo.create_dispatch_event(versions)
         logger.info(f"Waiting {minutes} minutes for any dispatch handlers")
         time.sleep(timedelta(minutes=minutes).total_seconds())
 
@@ -88,11 +88,11 @@ try:
     if gpg:
         repo.configure_gpg(gpg, get_input("gpg_password"))
 
-    for package_version, sha in package_versions.items():
-        logger.info(f"Processing version {package_version} ({sha})")
-        if get_input("branches", "false") == "true": #TODO: what happens here and why?!
-            repo.handle_release_branch(package_version)
-        repo.create_release(package_version, sha)
+    for version, sha in versions.items():
+        logger.info(f"Processing version {version} ({sha})")
+        if get_input("branches", "false") == "true":
+            repo.handle_release_branch(version)
+        repo.create_release(version, sha)
 except Exception as e:
     try:
         repo.handle_error(e)

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -62,6 +62,7 @@ try:
         email=get_input("email"),
         lookback=int(get_input("lookback")),
         branch=get_input("branch"),
+        subpackage=get_input("subpackage"),
     )
 
     if not repo.is_registered():

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -62,8 +62,7 @@ try:
         email=get_input("email"),
         lookback=int(get_input("lookback")),
         branch=get_input("branch"),
-        subpackage_name=get_input("subpackage_name"),
-        subpackage_uuid=get_input("subpackage_uuid"),
+        subdir=get_input("subdir"),
     )
 
     if not repo.is_registered():

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -62,7 +62,8 @@ try:
         email=get_input("email"),
         lookback=int(get_input("lookback")),
         branch=get_input("branch"),
-        subpackage=get_input("subpackage"),
+        subpackage_name=get_input("subpackage_name"),
+        subpackage_uuid=get_input("subpackage_uuid"),
     )
 
     if not repo.is_registered():

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -106,9 +106,9 @@ class Changelog:
         ]
 
     def _package_version_from_version_tag(self, version_tag: str) -> str:
-        """Return package version by stripping tag prefix from tag version"""
+        """Return package version by stripping subpackage prefix (if present) from tag version"""
         tag_prefix = self._repo._tag_prefix()
-        return version_tag[len(tag_prefix):]
+        return version_tag[len(tag_prefix)-1:]
 
     def _custom_release_notes(self, version_tag: str) -> Optional[str]:
         """Look up a version's custom release notes."""

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -44,11 +44,9 @@ class Changelog:
 
     def _previous_release(self, version_tag: str) -> Optional[GitRelease]:
         """Get the release previous to the current one (according to SemVer)."""
-        # package_version = self._package_version_from_version_tag(version_tag)
         tag_prefix = self._repo._tag_prefix()
-        package_version = version_tag[len(tag_prefix):]
-
-        cur_ver = VersionInfo.parse(package_version)
+        i_start = len(tag_prefix)
+        cur_ver = VersionInfo.parse(version_tag[i_start:])
         prev_ver = VersionInfo(0)
         prev_rel = None
         tag_prefix = self._repo._tag_prefix()
@@ -56,7 +54,7 @@ class Changelog:
             if not r.tag_name.startswith(tag_prefix):
                 continue
             try:
-                ver = VersionInfo.parse(r.tag_name[len(tag_prefix)-1:])
+                ver = VersionInfo.parse(r.tag_name[i_start:])
             except ValueError:
                 continue
             if ver.prerelease or ver.build:
@@ -113,7 +111,8 @@ class Changelog:
         logger.debug("Looking up custom release notes")
 
         tag_prefix = self._repo._tag_prefix()
-        package_version = version_tag[len(tag_prefix)-1:]
+        i_start = len(tag_prefix) - 1
+        package_version = version_tag[i_start:]
 
         pr = self._repo._registry_pr(package_version)
         if not pr:

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -44,16 +44,16 @@ class Changelog:
 
     def _previous_release(self, version_tag: str) -> Optional[GitRelease]:
         """Get the release previous to the current one (according to SemVer)."""
-        tag_prefix = self._repo._tag_prefix()
         package_version = self._package_version_from_version_tag(version_tag)
         cur_ver = VersionInfo.parse(package_version)
         prev_ver = VersionInfo(0)
         prev_rel = None
+        tag_prefix = self._repo._tag_prefix()
         for r in self._repo._repo.get_releases():
             if not r.tag_name.startswith(tag_prefix):
                 continue
             try:
-                ver = VersionInfo.parse(r.tag_name[len(tag_prefix):])
+                ver = VersionInfo.parse(r.tag_name[len(tag_prefix)-1:])
             except ValueError:
                 continue
             if ver.prerelease or ver.build:

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -44,7 +44,10 @@ class Changelog:
 
     def _previous_release(self, version_tag: str) -> Optional[GitRelease]:
         """Get the release previous to the current one (according to SemVer)."""
-        package_version = self._package_version_from_version_tag(version_tag)
+        # package_version = self._package_version_from_version_tag(version_tag)
+        tag_prefix = self._repo._tag_prefix()
+        package_version = version_tag[len(tag_prefix):]
+
         cur_ver = VersionInfo.parse(package_version)
         prev_ver = VersionInfo(0)
         prev_rel = None
@@ -105,15 +108,13 @@ class Changelog:
             p for p in self._issues_and_pulls(start, end) if isinstance(p, PullRequest)
         ]
 
-    def _package_version_from_version_tag(self, version_tag: str) -> str:
-        """Return package version by stripping subpackage prefix (if present) from tag version"""
-        tag_prefix = self._repo._tag_prefix()
-        return version_tag[len(tag_prefix)-1:]
-
     def _custom_release_notes(self, version_tag: str) -> Optional[str]:
         """Look up a version's custom release notes."""
         logger.debug("Looking up custom release notes")
-        package_version = self._package_version_from_version_tag(version_tag)
+
+        tag_prefix = self._repo._tag_prefix()
+        package_version = version_tag[len(tag_prefix)-1:]
+
         pr = self._repo._registry_pr(package_version)
         if not pr:
             logger.warning("No registry pull request was found for this version")

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -42,10 +42,10 @@ class Changelog:
         """Return a version of the string that's easy to compare."""
         return re.sub(r"[\s_-]", "", s.casefold())
 
-    def _previous_release(self, tag_version: str) -> Optional[GitRelease]:
+    def _previous_release(self, version_tag: str) -> Optional[GitRelease]:
         """Get the release previous to the current one (according to SemVer)."""
         tag_prefix = self._repo._tag_prefix()
-        package_version = self._package_version_from_tag_version(tag_version)
+        package_version = self._package_version_from_version_tag(version_tag)
         cur_ver = VersionInfo.parse(package_version)
         prev_ver = VersionInfo(0)
         prev_rel = None
@@ -105,15 +105,15 @@ class Changelog:
             p for p in self._issues_and_pulls(start, end) if isinstance(p, PullRequest)
         ]
 
-    def _package_version_from_tag_version(self, tag_version: str) -> str:
+    def _package_version_from_version_tag(self, version_tag: str) -> str:
         """Return package version by stripping tag prefix from tag version"""
         tag_prefix = self._repo._tag_prefix()
-        return tag_version[len(tag_prefix):]
+        return version_tag[len(tag_prefix):]
 
-    def _custom_release_notes(self, tag_version: str) -> Optional[str]:
+    def _custom_release_notes(self, version_tag: str) -> Optional[str]:
         """Look up a version's custom release notes."""
         logger.debug("Looking up custom release notes")
-        package_version = self._package_version_from_tag_version(tag_version)
+        package_version = self._package_version_from_version_tag(version_tag)
         pr = self._repo._registry_pr(package_version)
         if not pr:
             logger.warning("No registry pull request was found for this version")
@@ -161,16 +161,16 @@ class Changelog:
             "url": pull.html_url,
         }
 
-    def _collect_data(self, tag_version: str, sha: str) -> Dict[str, object]:
+    def _collect_data(self, version_tag: str, sha: str) -> Dict[str, object]:
         """Collect data needed to create the changelog."""
-        previous = self._previous_release(tag_version)
+        previous = self._previous_release(version_tag)
         start = datetime.fromtimestamp(0)
         prev_tag = None
         compare = None
         if previous:
             start = previous.created_at
             prev_tag = previous.tag_name
-            compare = f"{self._repo._repo.html_url}/compare/{prev_tag}...{tag_version}"
+            compare = f"{self._repo._repo.html_url}/compare/{prev_tag}...{version_tag}"
         # When the last commit is a PR merge, the commit happens a second or two before
         # the PR and associated issues are closed.
         end = self._repo._git.time_of_commit(sha) + timedelta(minutes=1)
@@ -181,23 +181,23 @@ class Changelog:
         pulls = self._pulls(start, end)
         return {
             "compare_url": compare,
-            "custom": self._custom_release_notes(tag_version),
+            "custom": self._custom_release_notes(version_tag),
             "issues": [self._format_issue(i) for i in issues],
             "package": self._repo._package_name(),
             "previous_release": prev_tag,
             "pulls": [self._format_pull(p) for p in pulls],
             "sha": sha,
-            "version": tag_version,
-            "version_url": f"{self._repo._repo.html_url}/tree/{tag_version}",
+            "version": version_tag,
+            "version_url": f"{self._repo._repo.html_url}/tree/{version_tag}",
         }
 
     def _render(self, data: Dict[str, object]) -> str:
         """Render the template."""
         return self._template.render(data).strip()
 
-    def get(self, tag_version: str, sha: str) -> str:
+    def get(self, version_tag: str, sha: str) -> str:
         """Get the changelog for a specific version."""
-        logger.info(f"Generating changelog for version {tag_version} ({sha})")
-        data = self._collect_data(tag_version, sha)
+        logger.info(f"Generating changelog for version {version_tag} ({sha})")
+        data = self._collect_data(version_tag, sha)
         logger.debug(f"Changelog data: {json.dumps(data, indent=2)}")
         return self._render(data)

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -105,7 +105,7 @@ class Changelog:
             p for p in self._issues_and_pulls(start, end) if isinstance(p, PullRequest)
         ]
 
-    def _package_version_from_tag_version(self, tag_version: str) -> str
+    def _package_version_from_tag_version(self, tag_version: str) -> str:
         """Return package version by stripping tag prefix from tag version"""
         tag_prefix = self._repo._tag_prefix()
         return tag_version[len(tag_prefix):]
@@ -183,7 +183,7 @@ class Changelog:
             "compare_url": compare,
             "custom": self._custom_release_notes(tag_version),
             "issues": [self._format_issue(i) for i in issues],
-            "package": self._package_name(),
+            "package": self._repo._package_name(),
             "previous_release": prev_tag,
             "pulls": [self._format_pull(p) for p in pulls],
             "sha": sha,

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -109,11 +109,9 @@ class Changelog:
     def _custom_release_notes(self, version_tag: str) -> Optional[str]:
         """Look up a version's custom release notes."""
         logger.debug("Looking up custom release notes")
-
         tag_prefix = self._repo._tag_prefix()
         i_start = len(tag_prefix) - 1
         package_version = version_tag[i_start:]
-
         pr = self._repo._registry_pr(package_version)
         if not pr:
             logger.warning("No registry pull request was found for this version")

--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -183,7 +183,7 @@ class Changelog:
             "compare_url": compare,
             "custom": self._custom_release_notes(version_tag),
             "issues": [self._format_issue(i) for i in issues],
-            "package": self._repo._package_name(),
+            "package": self._repo._project("name"),
             "previous_release": prev_tag,
             "pulls": [self._format_pull(p) for p in pulls],
             "sha": sha,

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -53,7 +53,8 @@ class Repo:
         email: str,
         lookback: int,
         branch: Optional[str],
-        subpackage: Optional[str],
+        subpackage_name: Optional[str] = None,
+        subpackage_uuid: Optional[str] = None,
         github_kwargs: Optional[Dict[str, object]] = None,
     ) -> None:
         if github_kwargs is None:
@@ -99,7 +100,8 @@ class Repo:
         self._lookback = timedelta(days=lookback, hours=1)
         self.__registry_clone_dir: Optional[str] = None
         self.__release_branch = branch
-        self.__subpackage_uuid = subpackage #TODO: name and uuid??
+        self.__subpackage_name = subpackage_name
+        self.__subpackage_uuid = subpackage_uuid
         self.__project: Optional[MutableMapping[str, object]] = None
         self.__registry_path: Optional[str] = None
 
@@ -175,7 +177,7 @@ class Repo:
 
     def _package_name(self) -> str:
         """Return the package name."""
-        if self.__subpackage_name is "":
+        if self.__subpackage_name is None:
             try:
                 name = self._project("name")
             except KeyError:
@@ -186,7 +188,7 @@ class Repo:
 
     def _package_uuid(self) -> str:
         """Return the package uuid."""
-        if self.__subpackage_uuid is "":
+        if self.__subpackage_uuid is None:
             try:
                 uuid = self._project("uuid")
             except KeyError:
@@ -197,7 +199,7 @@ class Repo:
 
     def _tag_prefix(self) -> str:
         """Return the package's tag prefix."""
-        if self.__subpackage_uuid is "":
+        if self.__subpackage_name is None:
             prefix = "v"
         else:
             prefix = self._package_name() + "-v"

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -430,7 +430,7 @@ class Repo:
         # I'm not really sure why mypy doesn't like this line without the cast.
         return cast(bool, m[1].casefold() == self._repo.full_name.casefold())
 
-    def new_package_versions(self) -> Dict[str, str]:
+    def new_versions(self) -> Dict[str, str]:
         """Get all new versions of the package."""
         current = self._versions()
         logger.debug(f"There are {len(current)} total versions")

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -179,15 +179,14 @@ class Repo:
         if self.__subdir is None:
             prefix = "v"
         else:
-            prefix = self._package_name() + "-v"
+            prefix = self._project("name") + "-v"
         return prefix
 
     def _get_version_tag(self, package_version: str) -> str:
-        """Return the package's tag prefix."""
+        """Return the package-prefixed version tag."""
         if package_version.startswith("v"):
             package_version = version[1:]
         return self._tag_prefix() + package_version
-
 
     def _registry_pr(self, version: str) -> Optional[PullRequest]:
         """Look up a merged registry pull request for this version."""
@@ -546,7 +545,6 @@ class Repo:
             # If we use <branch> as the target, GitHub will show
             # "<n> commits to <branch> since this release" on the release page.
             target = self._release_branch
-
         version_tag = self._get_version_tag(version)
         logger.debug(f"Release {version_tag} target: {target}")
         log = self._changelog.get(version_tag, sha)

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -589,7 +589,7 @@ class Repo:
         """Get the commit SHA from a registered version."""
         if package_version.startswith("v"):
             package_version = package_version[1:]
-        root = self._registry_path #TODO: check if this is correct...whould be 
+        root = self._registry_path
         if not root:
             logger.error("Package is not registered")
             return None

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -109,10 +109,7 @@ class Repo:
             return str(self.__project[k])
         for name in ["Project.toml", "JuliaProject.toml"]:
             try:
-                if self.__subdir is not None:
-                    filepath = os.path.join(self.__subdir, name)
-                else:
-                    filepath = name
+                filepath = os.path.join(self.__subdir, name) if self.__subdir else name
                 contents = self._only(self._repo.get_contents(filepath))
                 break
             except UnknownObjectException:
@@ -180,11 +177,7 @@ class Repo:
 
     def _tag_prefix(self) -> str:
         """Return the package's tag prefix."""
-        if self.__subdir is None or self.__subdir == "":
-            prefix = "v"
-        else:
-            prefix = self._project("name") + "-v"
-        return prefix
+        return self._project("name") + "-v" if self.__subdir else "v"
 
     def _get_version_tag(self, package_version: str) -> str:
         """Return the package-prefixed version tag."""

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -175,31 +175,9 @@ class Repo:
             base=self._repo.default_branch,
         )
 
-    def _package_name(self) -> str:
-        """Return the package name."""
-        if self.__subpackage_name is None:
-            try:
-                name = self._project("name")
-            except KeyError:
-                raise InvalidProject("Project file has no name")
-        else:
-            name = self.__subpackage_name
-        return name
-
-    def _package_uuid(self) -> str:
-        """Return the package uuid."""
-        if self.__subpackage_uuid is None:
-            try:
-                uuid = self._project("uuid")
-            except KeyError:
-                raise InvalidProject("Project file has no UUID")
-        else:
-            uuid = self.__subpackage_uuid
-        return uuid
-
     def _tag_prefix(self) -> str:
         """Return the package's tag prefix."""
-        if self.__subpackage_name is None:
+        if self.__subdir is None:
             prefix = "v"
         else:
             prefix = self._package_name() + "-v"
@@ -210,8 +188,8 @@ class Repo:
         if self._clone_registry:
             # I think this is actually possible, but it looks pretty complicated.
             return None
-        name = self._package_name()
-        uuid = self._package_uuid()
+        name = self._project("name")
+        uuid = self._project("uuid")
         # This is the format used by Registrator/PkgDev.
         head = f"registrator/{name.lower()}/{uuid[:8]}/{package_version}"
         logger.debug(f"Looking for PR from branch {head}")

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -53,6 +53,7 @@ class Repo:
         email: str,
         lookback: int,
         branch: Optional[str],
+        subpackage: Optional[str],
         github_kwargs: Optional[Dict[str, object]] = None,
     ) -> None:
         if github_kwargs is None:
@@ -98,6 +99,7 @@ class Repo:
         self._lookback = timedelta(days=lookback, hours=1)
         self.__registry_clone_dir: Optional[str] = None
         self.__release_branch = branch
+        self.__release_subpackage = subpackage
         self.__project: Optional[MutableMapping[str, object]] = None
         self.__registry_path: Optional[str] = None
 

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -180,7 +180,7 @@ class Repo:
 
     def _tag_prefix(self) -> str:
         """Return the package's tag prefix."""
-        if self.__subdir is None:
+        if self.__subdir is None or self.__subdir == "":
             prefix = "v"
         else:
             prefix = self._project("name") + "-v"

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -439,6 +439,7 @@ class Repo:
             ) as f:
                 package = toml.load(f)
         else:
+            #TODO: check this path
             contents = self._only(self._registry.get_contents(f"{root}/Package.toml"))
             package = toml.loads(contents.decoded_content.decode())
         gh = cast(str, urlparse(self._gh_url).hostname).replace(".", r"\.")

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -109,7 +109,11 @@ class Repo:
             return str(self.__project[k])
         for name in ["Project.toml", "JuliaProject.toml"]:
             try:
-                contents = self._only(self._repo.get_contents(os.path.join(self.__subdir, name)))
+                if self.__subdir is not None:
+                    filepath = os.path.join(self.__subdir, name)
+                else:
+                    filepath = name
+                contents = self._only(self._repo.get_contents(filepath))
                 break
             except UnknownObjectException:
                 pass
@@ -185,7 +189,7 @@ class Repo:
     def _get_version_tag(self, package_version: str) -> str:
         """Return the package-prefixed version tag."""
         if package_version.startswith("v"):
-            package_version = version[1:]
+            package_version = package_version[1:]
         return self._tag_prefix() + package_version
 
     def _registry_pr(self, version: str) -> Optional[PullRequest]:
@@ -520,7 +524,7 @@ class Repo:
     def handle_release_branch(self, version: str) -> None:
         """Merge an existing release branch or create a PR to merge it."""
         # Exclude "v" from version: `0.0.0` or `SubPackage-0.0.0`
-        branch_version = self._tag_prefix()[:-1] + version
+        branch_version = self._tag_prefix()[:-1] + version[1:]
         branch = f"release-{branch_version}"
         if not self._git.fetch_branch(branch):
             logger.info(f"Release branch {branch} does not exist")

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -550,7 +550,7 @@ class Repo:
 
         version_tag = self._get_version_tag(version)
         logger.debug(f"Release {version_tag} target: {target}")
-        log = self._changelog.get(version_tag, sha) #TODO: this might not be right for submodule.....
+        log = self._changelog.get(version_tag, sha)
         if not self._draft:
             if self._ssh or self._gpg:
                 logger.debug("Creating tag via Git CLI")
@@ -596,13 +596,13 @@ class Repo:
         """Get the commit SHA from a registered version."""
         if version.startswith("v"):
             version = version[1:]
-        root = self._registry_path #TODO: check if this is correct...whould be 
+        root = self._registry_path
         if not root:
             logger.error("Package is not registered")
             return None
         if self._clone_registry:
             with open(
-                os.path.join(self._registry_clone_dir, root, "Versions.toml") #TODO: check path is correct
+                os.path.join(self._registry_clone_dir, root, "Versions.toml")
             ) as f:
                 versions = toml.load(f)
         else:

--- a/tagbot/local/__main__.py
+++ b/tagbot/local/__main__.py
@@ -58,11 +58,13 @@ def main(
         subpackage_name=subpackage_name,
         subpackage_uuid=subpackage_uuid,
     )
-    #TODO: parse version into these correctly here
+    ## TODO: parse version into these correctly here
     package_version = ""
     tag_version = ""
 
-    package_version = package_version if package_version.startswith("v") else f"v{package_version}"
+    package_version = package_version 
+    if not package_version.startswith("v"):
+        package_version = f"v{package_version}"
     sha = r.commit_sha_of_version(package_version)
     if sha:
         r.create_release(tag_version, sha)

--- a/tagbot/local/__main__.py
+++ b/tagbot/local/__main__.py
@@ -25,7 +25,8 @@ with (Path(__file__).parent.parent.parent / "action.yml").open() as f:
 @click.option("--changelog", default=CHANGELOG, help="Changelog template")
 @click.option("--registry", default=REGISTRY, help="Registry to search")
 @click.option("--draft", default=DRAFT, help="Create a draft release", is_flag=True)
-@click.option("--subpackage", default="", help="Subpackage in repo")
+@click.option("--subpackage_name", default=None, help="Name of subpackage in repo")
+@click.option("--subpackage_uuid", default=None, help="UUID of subpackage in repo")
 def main(
     repo: str,
     version: str,
@@ -35,7 +36,8 @@ def main(
     changelog: str,
     registry: str,
     draft: bool,
-    subpackage: str,
+    subpackage_name: str,
+    subpackage_uuid: str,
 ) -> None:
     r = Repo(
         repo=repo,
@@ -53,12 +55,17 @@ def main(
         email=EMAIL,
         lookback=0,
         branch=None,
-        subpackage="",
+        subpackage_name=subpackage_name,
+        subpackage_uuid=subpackage_uuid,
     )
-    version = version if version.startswith("v") else f"v{version}"
-    sha = r.commit_sha_of_version(version)
+    #TODO: parse version into these correctly here
+    package_version = ""
+    tag_version = ""
+
+    package_version = package_version if package_version.startswith("v") else f"v{package_version}"
+    sha = r.commit_sha_of_version(package_version)
     if sha:
-        r.create_release(version, sha)
+        r.create_release(tag_version, sha)
     else:
         print(f"Commit for {version} was not found")
 

--- a/tagbot/local/__main__.py
+++ b/tagbot/local/__main__.py
@@ -25,8 +25,7 @@ with (Path(__file__).parent.parent.parent / "action.yml").open() as f:
 @click.option("--changelog", default=CHANGELOG, help="Changelog template")
 @click.option("--registry", default=REGISTRY, help="Registry to search")
 @click.option("--draft", default=DRAFT, help="Create a draft release", is_flag=True)
-@click.option("--subpackage_name", default=None, help="Name of subpackage in repo")
-@click.option("--subpackage_uuid", default=None, help="UUID of subpackage in repo")
+@click.option("--subdir", default=None, help="Subdirectory path in repo")
 def main(
     repo: str,
     version: str,
@@ -36,8 +35,7 @@ def main(
     changelog: str,
     registry: str,
     draft: bool,
-    subpackage_name: str,
-    subpackage_uuid: str,
+    subdir: str,
 ) -> None:
     r = Repo(
         repo=repo,
@@ -55,8 +53,7 @@ def main(
         email=EMAIL,
         lookback=0,
         branch=None,
-        subpackage_name=subpackage_name,
-        subpackage_uuid=subpackage_uuid,
+        subdir=subdir,
     )
     ## TODO: parse version into these correctly here
     package_version = ""

--- a/tagbot/local/__main__.py
+++ b/tagbot/local/__main__.py
@@ -25,6 +25,7 @@ with (Path(__file__).parent.parent.parent / "action.yml").open() as f:
 @click.option("--changelog", default=CHANGELOG, help="Changelog template")
 @click.option("--registry", default=REGISTRY, help="Registry to search")
 @click.option("--draft", default=DRAFT, help="Create a draft release", is_flag=True)
+@click.option("--subpackage", default="", help="Subpackage in repo")
 def main(
     repo: str,
     version: str,
@@ -34,6 +35,7 @@ def main(
     changelog: str,
     registry: str,
     draft: bool,
+    subpackage: str,
 ) -> None:
     r = Repo(
         repo=repo,
@@ -51,6 +53,7 @@ def main(
         email=EMAIL,
         lookback=0,
         branch=None,
+        subpackage="",
     )
     version = version if version.startswith("v") else f"v{version}"
     sha = r.commit_sha_of_version(version)

--- a/tagbot/local/__main__.py
+++ b/tagbot/local/__main__.py
@@ -55,16 +55,10 @@ def main(
         branch=None,
         subdir=subdir,
     )
-    ## TODO: parse version into these correctly here
-    package_version = ""
-    tag_version = ""
-
-    package_version = package_version 
-    if not package_version.startswith("v"):
-        package_version = f"v{package_version}"
-    sha = r.commit_sha_of_version(package_version)
+    version = version if version.startswith("v") else f"v{version}"
+    sha = r.commit_sha_of_version(version)
     if sha:
-        r.create_release(tag_version, sha)
+        r.create_release(version, sha)
     else:
         print(f"Commit for {version} was not found")
 

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -29,7 +29,6 @@ def _changelog(*, template="", ignore=set()):
         email="",
         lookback=3,
         branch=None,
-        subpackage="",
     )
     return r._changelog
 

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -57,7 +57,16 @@ def test_previous_release_subdir():
     c._repo._repo.get_contents = Mock(
         return_value=Mock(decoded_content=b"""name = "Foo"\nuuid="abc-def"\n""")
     )
-    tags = ["ignore", "v1.2.4-ignore", "Foo-v1.2.3", "Foo-v1.2.2", "Foo-v1.0.2", "Foo-v1.0.10", "v2.0.1", "Foo-v2.0.0"]
+    tags = [
+        "ignore",
+        "v1.2.4-ignore",
+        "Foo-v1.2.3",
+        "Foo-v1.2.2",
+        "Foo-v1.0.2",
+        "Foo-v1.0.10",
+        "v2.0.1",
+        "Foo-v2.0.0",
+    ]
     c._repo._repo.get_releases = Mock(return_value=[Mock(tag_name=t) for t in tags])
     assert c._previous_release("Foo-v1.0.0") is None
     assert c._previous_release("Foo-v1.0.2") is None

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -29,6 +29,7 @@ def _changelog(*, template="", ignore=set()):
         email="",
         lookback=3,
         branch=None,
+        subpackage="",
     )
     return r._changelog
 

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -33,9 +33,9 @@ def _changelog(*, template="", ignore=set()):
     return r._changelog
 
 
-# def test_slug():
-#     c = _changelog()
-#     assert c._slug("A b-c_d") == "abcd"
+def test_slug():
+    c = _changelog()
+    assert c._slug("A b-c_d") == "abcd"
 
 
 def test_previous_release():

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -33,9 +33,9 @@ def _changelog(*, template="", ignore=set()):
     return r._changelog
 
 
-def test_slug():
-    c = _changelog()
-    assert c._slug("A b-c_d") == "abcd"
+# def test_slug():
+#     c = _changelog()
+#     assert c._slug("A b-c_d") == "abcd"
 
 
 def test_previous_release():
@@ -50,188 +50,188 @@ def test_previous_release():
     assert rel and rel.tag_name == "v1.0.2"
 
 
-def test_issues_and_pulls():
-    c = _changelog()
-    now = datetime.now()
-    start = now - timedelta(days=10)
-    end = now
-    c._repo._repo.get_issues = Mock(return_value=[])
-    assert c._issues_and_pulls(end, end) == []
-    assert c._issues_and_pulls(end, end) == []
-    c._repo._repo.get_issues.assert_called_once_with(state="closed", since=end)
-    assert c._issues_and_pulls(end, end) == []
-    c._repo._repo.get_issues.assert_called_with(state="closed", since=end)
-    n = 1
-    for days in [-1, 0, 5, 10, 11]:
-        i = Mock(
-            closed_at=end - timedelta(days=days), n=n, pull_request=False, labels=[]
-        )
-        p = Mock(
-            closed_at=end - timedelta(days=days),
-            pull_request=True,
-            labels=[],
-            as_pull_request=Mock(return_value=Mock(merged=days % 2 == 0, n=n + 1)),
-        )
-        n += 2
-        c._repo._repo.get_issues.return_value.extend([i, p])
-    assert [x.n for x in c._issues_and_pulls(start, end)] == [5, 4, 3]
+# def test_issues_and_pulls():
+#     c = _changelog()
+#     now = datetime.now()
+#     start = now - timedelta(days=10)
+#     end = now
+#     c._repo._repo.get_issues = Mock(return_value=[])
+#     assert c._issues_and_pulls(end, end) == []
+#     assert c._issues_and_pulls(end, end) == []
+#     c._repo._repo.get_issues.assert_called_once_with(state="closed", since=end)
+#     assert c._issues_and_pulls(end, end) == []
+#     c._repo._repo.get_issues.assert_called_with(state="closed", since=end)
+#     n = 1
+#     for days in [-1, 0, 5, 10, 11]:
+#         i = Mock(
+#             closed_at=end - timedelta(days=days), n=n, pull_request=False, labels=[]
+#         )
+#         p = Mock(
+#             closed_at=end - timedelta(days=days),
+#             pull_request=True,
+#             labels=[],
+#             as_pull_request=Mock(return_value=Mock(merged=days % 2 == 0, n=n + 1)),
+#         )
+#         n += 2
+#         c._repo._repo.get_issues.return_value.extend([i, p])
+#     assert [x.n for x in c._issues_and_pulls(start, end)] == [5, 4, 3]
 
 
-def test_issues_pulls():
-    c = _changelog()
-    mocks = []
-    for i in range(0, 20, 2):
-        mocks.append(Mock(spec=Issue, number=i))
-        mocks.append(Mock(spec=PullRequest, number=i + 1))
-    c._issues_and_pulls = Mock(return_value=mocks)
-    a = datetime(1, 1, 1)
-    b = datetime(2, 2, 2)
-    assert all(isinstance(x, Issue) and not x.number % 2 for x in c._issues(a, b))
-    c._issues_and_pulls.assert_called_with(a, b)
-    assert all(isinstance(x, PullRequest) and x.number % 2 for x in c._pulls(b, a))
-    c._issues_and_pulls.assert_called_with(b, a)
+# def test_issues_pulls():
+#     c = _changelog()
+#     mocks = []
+#     for i in range(0, 20, 2):
+#         mocks.append(Mock(spec=Issue, number=i))
+#         mocks.append(Mock(spec=PullRequest, number=i + 1))
+#     c._issues_and_pulls = Mock(return_value=mocks)
+#     a = datetime(1, 1, 1)
+#     b = datetime(2, 2, 2)
+#     assert all(isinstance(x, Issue) and not x.number % 2 for x in c._issues(a, b))
+#     c._issues_and_pulls.assert_called_with(a, b)
+#     assert all(isinstance(x, PullRequest) and x.number % 2 for x in c._pulls(b, a))
+#     c._issues_and_pulls.assert_called_with(b, a)
 
 
-def test_custom_release_notes():
-    c = _changelog()
-    notes = """
-    blah blah blah
-    <!-- BEGIN RELEASE NOTES -->
-    > Foo
-    > Bar
-    <!-- END RELEASE NOTES -->
-    blah blah blah
-    """
-    notes = textwrap.dedent(notes)
-    c._repo._registry_pr = Mock(side_effect=[None, Mock(body="foo"), Mock(body=notes)])
-    assert c._custom_release_notes("v1.2.3") is None
-    c._repo._registry_pr.assert_called_with("v1.2.3")
-    assert c._custom_release_notes("v2.3.4") is None
-    c._repo._registry_pr.assert_called_with("v2.3.4")
-    assert c._custom_release_notes("v3.4.5") == "Foo\nBar"
-    c._repo._registry_pr.assert_called_with("v3.4.5")
+# def test_custom_release_notes():
+#     c = _changelog()
+#     notes = """
+#     blah blah blah
+#     <!-- BEGIN RELEASE NOTES -->
+#     > Foo
+#     > Bar
+#     <!-- END RELEASE NOTES -->
+#     blah blah blah
+#     """
+#     notes = textwrap.dedent(notes)
+#     c._repo._registry_pr = Mock(side_effect=[None, Mock(body="foo"), Mock(body=notes)])
+#     assert c._custom_release_notes("v1.2.3") is None
+#     c._repo._registry_pr.assert_called_with("v1.2.3")
+#     assert c._custom_release_notes("v2.3.4") is None
+#     c._repo._registry_pr.assert_called_with("v2.3.4")
+#     assert c._custom_release_notes("v3.4.5") == "Foo\nBar"
+#     c._repo._registry_pr.assert_called_with("v3.4.5")
 
 
-def test_format_user():
-    c = _changelog()
-    m = Mock(html_url="url", login="username")
-    m.name = "Name"
-    assert c._format_user(m) == {"name": "Name", "url": "url", "username": "username"}
-    assert c._format_user(None) == {}
+# def test_format_user():
+#     c = _changelog()
+#     m = Mock(html_url="url", login="username")
+#     m.name = "Name"
+#     assert c._format_user(m) == {"name": "Name", "url": "url", "username": "username"}
+#     assert c._format_user(None) == {}
 
 
-def test_format_issue_pull():
-    c = _changelog()
-    m = Mock(
-        user=Mock(html_url="url", login="username"),
-        closed_by=Mock(html_url="url", login="username"),
-        merged_by=Mock(html_url="url", login="username"),
-        body="body",
-        labels=[Mock(), Mock()],
-        number=1,
-        title="title",
-        html_url="url",
-    )
-    m.user.name = "User"
-    m.closed_by.name = "Closer"
-    m.merged_by.name = "Merger"
-    m.labels[0].name = "label1"
-    m.labels[1].name = "label2"
-    assert c._format_issue(m) == {
-        "author": {"name": "User", "url": "url", "username": "username"},
-        "body": "body",
-        "labels": ["label1", "label2"],
-        "closer": {"name": "Closer", "url": "url", "username": "username"},
-        "number": 1,
-        "title": "title",
-        "url": "url",
-    }
-    assert c._format_pull(m) == {
-        "author": {"name": "User", "url": "url", "username": "username"},
-        "body": "body",
-        "labels": ["label1", "label2"],
-        "merger": {"name": "Merger", "url": "url", "username": "username"},
-        "number": 1,
-        "title": "title",
-        "url": "url",
-    }
+# def test_format_issue_pull():
+#     c = _changelog()
+#     m = Mock(
+#         user=Mock(html_url="url", login="username"),
+#         closed_by=Mock(html_url="url", login="username"),
+#         merged_by=Mock(html_url="url", login="username"),
+#         body="body",
+#         labels=[Mock(), Mock()],
+#         number=1,
+#         title="title",
+#         html_url="url",
+#     )
+#     m.user.name = "User"
+#     m.closed_by.name = "Closer"
+#     m.merged_by.name = "Merger"
+#     m.labels[0].name = "label1"
+#     m.labels[1].name = "label2"
+#     assert c._format_issue(m) == {
+#         "author": {"name": "User", "url": "url", "username": "username"},
+#         "body": "body",
+#         "labels": ["label1", "label2"],
+#         "closer": {"name": "Closer", "url": "url", "username": "username"},
+#         "number": 1,
+#         "title": "title",
+#         "url": "url",
+#     }
+#     assert c._format_pull(m) == {
+#         "author": {"name": "User", "url": "url", "username": "username"},
+#         "body": "body",
+#         "labels": ["label1", "label2"],
+#         "merger": {"name": "Merger", "url": "url", "username": "username"},
+#         "number": 1,
+#         "title": "title",
+#         "url": "url",
+#     }
 
 
-def test_collect_data():
-    c = _changelog()
-    c._repo._repo = Mock(full_name="A/B.jl", html_url="https://github.com/A/B.jl")
-    c._repo._project = Mock(return_value="B")
-    c._previous_release = Mock(
-        side_effect=[Mock(tag_name="v1.2.2", created_at=datetime.now()), None]
-    )
-    c._repo._git.time_of_commit = Mock(return_value=datetime.now())
-    # TODO: Put stuff here.
-    c._issues = Mock(return_value=[])
-    c._pulls = Mock(return_value=[])
-    c._custom_release_notes = Mock(return_value="custom")
-    assert c._collect_data("v1.2.3", "abcdef") == {
-        "compare_url": "https://github.com/A/B.jl/compare/v1.2.2...v1.2.3",
-        "custom": "custom",
-        "issues": [],
-        "package": "B",
-        "previous_release": "v1.2.2",
-        "pulls": [],
-        "sha": "abcdef",
-        "version": "v1.2.3",
-        "version_url": "https://github.com/A/B.jl/tree/v1.2.3",
-    }
-    data = c._collect_data("v2.3.4", "bcdefa")
-    assert data["compare_url"] is None
-    assert data["previous_release"] is None
+# def test_collect_data():
+#     c = _changelog()
+#     c._repo._repo = Mock(full_name="A/B.jl", html_url="https://github.com/A/B.jl")
+#     c._repo._project = Mock(return_value="B")
+#     c._previous_release = Mock(
+#         side_effect=[Mock(tag_name="v1.2.2", created_at=datetime.now()), None]
+#     )
+#     c._repo._git.time_of_commit = Mock(return_value=datetime.now())
+#     # TODO: Put stuff here.
+#     c._issues = Mock(return_value=[])
+#     c._pulls = Mock(return_value=[])
+#     c._custom_release_notes = Mock(return_value="custom")
+#     assert c._collect_data("v1.2.3", "abcdef") == {
+#         "compare_url": "https://github.com/A/B.jl/compare/v1.2.2...v1.2.3",
+#         "custom": "custom",
+#         "issues": [],
+#         "package": "B",
+#         "previous_release": "v1.2.2",
+#         "pulls": [],
+#         "sha": "abcdef",
+#         "version": "v1.2.3",
+#         "version_url": "https://github.com/A/B.jl/tree/v1.2.3",
+#     }
+#     data = c._collect_data("v2.3.4", "bcdefa")
+#     assert data["compare_url"] is None
+#     assert data["previous_release"] is None
 
 
-def test_render():
-    path = os.path.join(os.path.dirname(__file__), "..", "..", "action.yml")
-    with open(path) as f:
-        action = yaml.safe_load(f)
-    default = action["inputs"]["changelog"]["default"]
-    c = _changelog(template=default)
-    expected = """
-    ## PkgName v1.2.3
+# def test_render():
+#     path = os.path.join(os.path.dirname(__file__), "..", "..", "action.yml")
+#     with open(path) as f:
+#         action = yaml.safe_load(f)
+#     default = action["inputs"]["changelog"]["default"]
+#     c = _changelog(template=default)
+#     expected = """
+#     ## PkgName v1.2.3
 
-    [Diff since v1.2.2](https://github.com/Me/PkgName.jl/compare/v1.2.2...v1.2.3)
+#     [Diff since v1.2.2](https://github.com/Me/PkgName.jl/compare/v1.2.2...v1.2.3)
 
-    Custom release notes
+#     Custom release notes
 
-    **Closed issues:**
-    - Issue title (#1)
+#     **Closed issues:**
+#     - Issue title (#1)
 
-    **Merged pull requests:**
-    - Pull title (#3) (@author)
-    """
-    data = {
-        "compare_url": "https://github.com/Me/PkgName.jl/compare/v1.2.2...v1.2.3",
-        "custom": "Custom release notes",
-        "issues": [{"number": 1, "title": "Issue title", "labels": []}],
-        "package": "PkgName",
-        "previous_release": "v1.2.2",
-        "pulls": [
-            {
-                "number": 3,
-                "title": "Pull title",
-                "labels": [],
-                "author": {"username": "author"},
-            },
-        ],
-        "version": "v1.2.3",
-        "version_url": "https://github.com/Me/PkgName.jl/tree/v1.2.3",
-    }
-    assert c._render(data) == textwrap.dedent(expected).strip()
-    del data["pulls"]
-    assert "**Merged pull requests:**" not in c._render(data)
-    del data["issues"]
-    assert "**Closed issues:**" not in c._render(data)
-    data["previous_release"] = None
-    assert "Diff since" not in c._render(data)
+#     **Merged pull requests:**
+#     - Pull title (#3) (@author)
+#     """
+#     data = {
+#         "compare_url": "https://github.com/Me/PkgName.jl/compare/v1.2.2...v1.2.3",
+#         "custom": "Custom release notes",
+#         "issues": [{"number": 1, "title": "Issue title", "labels": []}],
+#         "package": "PkgName",
+#         "previous_release": "v1.2.2",
+#         "pulls": [
+#             {
+#                 "number": 3,
+#                 "title": "Pull title",
+#                 "labels": [],
+#                 "author": {"username": "author"},
+#             },
+#         ],
+#         "version": "v1.2.3",
+#         "version_url": "https://github.com/Me/PkgName.jl/tree/v1.2.3",
+#     }
+#     assert c._render(data) == textwrap.dedent(expected).strip()
+#     del data["pulls"]
+#     assert "**Merged pull requests:**" not in c._render(data)
+#     del data["issues"]
+#     assert "**Closed issues:**" not in c._render(data)
+#     data["previous_release"] = None
+#     assert "Diff since" not in c._render(data)
 
 
-def test_get():
-    c = _changelog(template="{{ version }}")
-    c._collect_data = Mock(return_value={"version": "v1.2.3"})
-    assert c.get("v1.2.3", "abc") == "v1.2.3"
-    c._collect_data.assert_called_once_with("v1.2.3", "abc")
+# def test_get():
+#     c = _changelog(template="{{ version }}")
+#     c._collect_data = Mock(return_value={"version": "v1.2.3"})
+#     assert c.get("v1.2.3", "abc") == "v1.2.3"
+#     c._collect_data.assert_called_once_with("v1.2.3", "abc")

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -12,7 +12,7 @@ from github.PullRequest import PullRequest
 from tagbot.action.repo import Repo
 
 
-def _changelog(*, template="", ignore=set()):
+def _changelog(*, template="", ignore=set(), subdir=None):
     r = Repo(
         repo="",
         registry="",
@@ -29,6 +29,7 @@ def _changelog(*, template="", ignore=set()):
         email="",
         lookback=3,
         branch=None,
+        subdir=subdir,
     )
     return r._changelog
 
@@ -48,6 +49,24 @@ def test_previous_release():
     assert rel and rel.tag_name == "v1.2.3"
     rel = c._previous_release("v1.0.3")
     assert rel and rel.tag_name == "v1.0.2"
+
+
+def test_previous_release_subdir():
+    True
+    c = _changelog(subdir="Foo")
+    c._repo._repo.get_contents = Mock(
+        return_value=Mock(decoded_content=b"""name = "Foo"\nuuid="abc-def"\n""")
+    )
+    tags = ["ignore", "v1.2.4-ignore", "Foo-v1.2.3", "Foo-v1.2.2", "Foo-v1.0.2", "Foo-v1.0.10", "v2.0.1", "Foo-v2.0.0"]
+    c._repo._repo.get_releases = Mock(return_value=[Mock(tag_name=t) for t in tags])
+    assert c._previous_release("Foo-v1.0.0") is None
+    assert c._previous_release("Foo-v1.0.2") is None
+    rel = c._previous_release("Foo-v1.2.5")
+    assert rel and rel.tag_name == "Foo-v1.2.3"
+    rel = c._previous_release("Foo-v1.0.3")
+    assert rel and rel.tag_name == "Foo-v1.0.2"
+    rel = c._previous_release("Foo-v2.1.0")
+    assert rel and rel.tag_name == "Foo-v2.0.0"
 
 
 def test_issues_and_pulls():
@@ -235,3 +254,8 @@ def test_get():
     c._collect_data = Mock(return_value={"version": "v1.2.3"})
     assert c.get("v1.2.3", "abc") == "v1.2.3"
     c._collect_data.assert_called_once_with("v1.2.3", "abc")
+
+    c = _changelog(template="{{ version }}")
+    c._collect_data = Mock(return_value={"version": "Foo-v1.2.3"})
+    assert c.get("Foo-v1.2.3", "abc") == "Foo-v1.2.3"
+    c._collect_data.assert_called_once_with("Foo-v1.2.3", "abc")

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -50,188 +50,188 @@ def test_previous_release():
     assert rel and rel.tag_name == "v1.0.2"
 
 
-# def test_issues_and_pulls():
-#     c = _changelog()
-#     now = datetime.now()
-#     start = now - timedelta(days=10)
-#     end = now
-#     c._repo._repo.get_issues = Mock(return_value=[])
-#     assert c._issues_and_pulls(end, end) == []
-#     assert c._issues_and_pulls(end, end) == []
-#     c._repo._repo.get_issues.assert_called_once_with(state="closed", since=end)
-#     assert c._issues_and_pulls(end, end) == []
-#     c._repo._repo.get_issues.assert_called_with(state="closed", since=end)
-#     n = 1
-#     for days in [-1, 0, 5, 10, 11]:
-#         i = Mock(
-#             closed_at=end - timedelta(days=days), n=n, pull_request=False, labels=[]
-#         )
-#         p = Mock(
-#             closed_at=end - timedelta(days=days),
-#             pull_request=True,
-#             labels=[],
-#             as_pull_request=Mock(return_value=Mock(merged=days % 2 == 0, n=n + 1)),
-#         )
-#         n += 2
-#         c._repo._repo.get_issues.return_value.extend([i, p])
-#     assert [x.n for x in c._issues_and_pulls(start, end)] == [5, 4, 3]
+def test_issues_and_pulls():
+    c = _changelog()
+    now = datetime.now()
+    start = now - timedelta(days=10)
+    end = now
+    c._repo._repo.get_issues = Mock(return_value=[])
+    assert c._issues_and_pulls(end, end) == []
+    assert c._issues_and_pulls(end, end) == []
+    c._repo._repo.get_issues.assert_called_once_with(state="closed", since=end)
+    assert c._issues_and_pulls(end, end) == []
+    c._repo._repo.get_issues.assert_called_with(state="closed", since=end)
+    n = 1
+    for days in [-1, 0, 5, 10, 11]:
+        i = Mock(
+            closed_at=end - timedelta(days=days), n=n, pull_request=False, labels=[]
+        )
+        p = Mock(
+            closed_at=end - timedelta(days=days),
+            pull_request=True,
+            labels=[],
+            as_pull_request=Mock(return_value=Mock(merged=days % 2 == 0, n=n + 1)),
+        )
+        n += 2
+        c._repo._repo.get_issues.return_value.extend([i, p])
+    assert [x.n for x in c._issues_and_pulls(start, end)] == [5, 4, 3]
 
 
-# def test_issues_pulls():
-#     c = _changelog()
-#     mocks = []
-#     for i in range(0, 20, 2):
-#         mocks.append(Mock(spec=Issue, number=i))
-#         mocks.append(Mock(spec=PullRequest, number=i + 1))
-#     c._issues_and_pulls = Mock(return_value=mocks)
-#     a = datetime(1, 1, 1)
-#     b = datetime(2, 2, 2)
-#     assert all(isinstance(x, Issue) and not x.number % 2 for x in c._issues(a, b))
-#     c._issues_and_pulls.assert_called_with(a, b)
-#     assert all(isinstance(x, PullRequest) and x.number % 2 for x in c._pulls(b, a))
-#     c._issues_and_pulls.assert_called_with(b, a)
+def test_issues_pulls():
+    c = _changelog()
+    mocks = []
+    for i in range(0, 20, 2):
+        mocks.append(Mock(spec=Issue, number=i))
+        mocks.append(Mock(spec=PullRequest, number=i + 1))
+    c._issues_and_pulls = Mock(return_value=mocks)
+    a = datetime(1, 1, 1)
+    b = datetime(2, 2, 2)
+    assert all(isinstance(x, Issue) and not x.number % 2 for x in c._issues(a, b))
+    c._issues_and_pulls.assert_called_with(a, b)
+    assert all(isinstance(x, PullRequest) and x.number % 2 for x in c._pulls(b, a))
+    c._issues_and_pulls.assert_called_with(b, a)
 
 
-# def test_custom_release_notes():
-#     c = _changelog()
-#     notes = """
-#     blah blah blah
-#     <!-- BEGIN RELEASE NOTES -->
-#     > Foo
-#     > Bar
-#     <!-- END RELEASE NOTES -->
-#     blah blah blah
-#     """
-#     notes = textwrap.dedent(notes)
-#     c._repo._registry_pr = Mock(side_effect=[None, Mock(body="foo"), Mock(body=notes)])
-#     assert c._custom_release_notes("v1.2.3") is None
-#     c._repo._registry_pr.assert_called_with("v1.2.3")
-#     assert c._custom_release_notes("v2.3.4") is None
-#     c._repo._registry_pr.assert_called_with("v2.3.4")
-#     assert c._custom_release_notes("v3.4.5") == "Foo\nBar"
-#     c._repo._registry_pr.assert_called_with("v3.4.5")
+def test_custom_release_notes():
+    c = _changelog()
+    notes = """
+    blah blah blah
+    <!-- BEGIN RELEASE NOTES -->
+    > Foo
+    > Bar
+    <!-- END RELEASE NOTES -->
+    blah blah blah
+    """
+    notes = textwrap.dedent(notes)
+    c._repo._registry_pr = Mock(side_effect=[None, Mock(body="foo"), Mock(body=notes)])
+    assert c._custom_release_notes("v1.2.3") is None
+    c._repo._registry_pr.assert_called_with("v1.2.3")
+    assert c._custom_release_notes("v2.3.4") is None
+    c._repo._registry_pr.assert_called_with("v2.3.4")
+    assert c._custom_release_notes("v3.4.5") == "Foo\nBar"
+    c._repo._registry_pr.assert_called_with("v3.4.5")
 
 
-# def test_format_user():
-#     c = _changelog()
-#     m = Mock(html_url="url", login="username")
-#     m.name = "Name"
-#     assert c._format_user(m) == {"name": "Name", "url": "url", "username": "username"}
-#     assert c._format_user(None) == {}
+def test_format_user():
+    c = _changelog()
+    m = Mock(html_url="url", login="username")
+    m.name = "Name"
+    assert c._format_user(m) == {"name": "Name", "url": "url", "username": "username"}
+    assert c._format_user(None) == {}
 
 
-# def test_format_issue_pull():
-#     c = _changelog()
-#     m = Mock(
-#         user=Mock(html_url="url", login="username"),
-#         closed_by=Mock(html_url="url", login="username"),
-#         merged_by=Mock(html_url="url", login="username"),
-#         body="body",
-#         labels=[Mock(), Mock()],
-#         number=1,
-#         title="title",
-#         html_url="url",
-#     )
-#     m.user.name = "User"
-#     m.closed_by.name = "Closer"
-#     m.merged_by.name = "Merger"
-#     m.labels[0].name = "label1"
-#     m.labels[1].name = "label2"
-#     assert c._format_issue(m) == {
-#         "author": {"name": "User", "url": "url", "username": "username"},
-#         "body": "body",
-#         "labels": ["label1", "label2"],
-#         "closer": {"name": "Closer", "url": "url", "username": "username"},
-#         "number": 1,
-#         "title": "title",
-#         "url": "url",
-#     }
-#     assert c._format_pull(m) == {
-#         "author": {"name": "User", "url": "url", "username": "username"},
-#         "body": "body",
-#         "labels": ["label1", "label2"],
-#         "merger": {"name": "Merger", "url": "url", "username": "username"},
-#         "number": 1,
-#         "title": "title",
-#         "url": "url",
-#     }
+def test_format_issue_pull():
+    c = _changelog()
+    m = Mock(
+        user=Mock(html_url="url", login="username"),
+        closed_by=Mock(html_url="url", login="username"),
+        merged_by=Mock(html_url="url", login="username"),
+        body="body",
+        labels=[Mock(), Mock()],
+        number=1,
+        title="title",
+        html_url="url",
+    )
+    m.user.name = "User"
+    m.closed_by.name = "Closer"
+    m.merged_by.name = "Merger"
+    m.labels[0].name = "label1"
+    m.labels[1].name = "label2"
+    assert c._format_issue(m) == {
+        "author": {"name": "User", "url": "url", "username": "username"},
+        "body": "body",
+        "labels": ["label1", "label2"],
+        "closer": {"name": "Closer", "url": "url", "username": "username"},
+        "number": 1,
+        "title": "title",
+        "url": "url",
+    }
+    assert c._format_pull(m) == {
+        "author": {"name": "User", "url": "url", "username": "username"},
+        "body": "body",
+        "labels": ["label1", "label2"],
+        "merger": {"name": "Merger", "url": "url", "username": "username"},
+        "number": 1,
+        "title": "title",
+        "url": "url",
+    }
 
 
-# def test_collect_data():
-#     c = _changelog()
-#     c._repo._repo = Mock(full_name="A/B.jl", html_url="https://github.com/A/B.jl")
-#     c._repo._project = Mock(return_value="B")
-#     c._previous_release = Mock(
-#         side_effect=[Mock(tag_name="v1.2.2", created_at=datetime.now()), None]
-#     )
-#     c._repo._git.time_of_commit = Mock(return_value=datetime.now())
-#     # TODO: Put stuff here.
-#     c._issues = Mock(return_value=[])
-#     c._pulls = Mock(return_value=[])
-#     c._custom_release_notes = Mock(return_value="custom")
-#     assert c._collect_data("v1.2.3", "abcdef") == {
-#         "compare_url": "https://github.com/A/B.jl/compare/v1.2.2...v1.2.3",
-#         "custom": "custom",
-#         "issues": [],
-#         "package": "B",
-#         "previous_release": "v1.2.2",
-#         "pulls": [],
-#         "sha": "abcdef",
-#         "version": "v1.2.3",
-#         "version_url": "https://github.com/A/B.jl/tree/v1.2.3",
-#     }
-#     data = c._collect_data("v2.3.4", "bcdefa")
-#     assert data["compare_url"] is None
-#     assert data["previous_release"] is None
+def test_collect_data():
+    c = _changelog()
+    c._repo._repo = Mock(full_name="A/B.jl", html_url="https://github.com/A/B.jl")
+    c._repo._project = Mock(return_value="B")
+    c._previous_release = Mock(
+        side_effect=[Mock(tag_name="v1.2.2", created_at=datetime.now()), None]
+    )
+    c._repo._git.time_of_commit = Mock(return_value=datetime.now())
+    # TODO: Put stuff here.
+    c._issues = Mock(return_value=[])
+    c._pulls = Mock(return_value=[])
+    c._custom_release_notes = Mock(return_value="custom")
+    assert c._collect_data("v1.2.3", "abcdef") == {
+        "compare_url": "https://github.com/A/B.jl/compare/v1.2.2...v1.2.3",
+        "custom": "custom",
+        "issues": [],
+        "package": "B",
+        "previous_release": "v1.2.2",
+        "pulls": [],
+        "sha": "abcdef",
+        "version": "v1.2.3",
+        "version_url": "https://github.com/A/B.jl/tree/v1.2.3",
+    }
+    data = c._collect_data("v2.3.4", "bcdefa")
+    assert data["compare_url"] is None
+    assert data["previous_release"] is None
 
 
-# def test_render():
-#     path = os.path.join(os.path.dirname(__file__), "..", "..", "action.yml")
-#     with open(path) as f:
-#         action = yaml.safe_load(f)
-#     default = action["inputs"]["changelog"]["default"]
-#     c = _changelog(template=default)
-#     expected = """
-#     ## PkgName v1.2.3
+def test_render():
+    path = os.path.join(os.path.dirname(__file__), "..", "..", "action.yml")
+    with open(path) as f:
+        action = yaml.safe_load(f)
+    default = action["inputs"]["changelog"]["default"]
+    c = _changelog(template=default)
+    expected = """
+    ## PkgName v1.2.3
 
-#     [Diff since v1.2.2](https://github.com/Me/PkgName.jl/compare/v1.2.2...v1.2.3)
+    [Diff since v1.2.2](https://github.com/Me/PkgName.jl/compare/v1.2.2...v1.2.3)
 
-#     Custom release notes
+    Custom release notes
 
-#     **Closed issues:**
-#     - Issue title (#1)
+    **Closed issues:**
+    - Issue title (#1)
 
-#     **Merged pull requests:**
-#     - Pull title (#3) (@author)
-#     """
-#     data = {
-#         "compare_url": "https://github.com/Me/PkgName.jl/compare/v1.2.2...v1.2.3",
-#         "custom": "Custom release notes",
-#         "issues": [{"number": 1, "title": "Issue title", "labels": []}],
-#         "package": "PkgName",
-#         "previous_release": "v1.2.2",
-#         "pulls": [
-#             {
-#                 "number": 3,
-#                 "title": "Pull title",
-#                 "labels": [],
-#                 "author": {"username": "author"},
-#             },
-#         ],
-#         "version": "v1.2.3",
-#         "version_url": "https://github.com/Me/PkgName.jl/tree/v1.2.3",
-#     }
-#     assert c._render(data) == textwrap.dedent(expected).strip()
-#     del data["pulls"]
-#     assert "**Merged pull requests:**" not in c._render(data)
-#     del data["issues"]
-#     assert "**Closed issues:**" not in c._render(data)
-#     data["previous_release"] = None
-#     assert "Diff since" not in c._render(data)
+    **Merged pull requests:**
+    - Pull title (#3) (@author)
+    """
+    data = {
+        "compare_url": "https://github.com/Me/PkgName.jl/compare/v1.2.2...v1.2.3",
+        "custom": "Custom release notes",
+        "issues": [{"number": 1, "title": "Issue title", "labels": []}],
+        "package": "PkgName",
+        "previous_release": "v1.2.2",
+        "pulls": [
+            {
+                "number": 3,
+                "title": "Pull title",
+                "labels": [],
+                "author": {"username": "author"},
+            },
+        ],
+        "version": "v1.2.3",
+        "version_url": "https://github.com/Me/PkgName.jl/tree/v1.2.3",
+    }
+    assert c._render(data) == textwrap.dedent(expected).strip()
+    del data["pulls"]
+    assert "**Merged pull requests:**" not in c._render(data)
+    del data["issues"]
+    assert "**Closed issues:**" not in c._render(data)
+    data["previous_release"] = None
+    assert "Diff since" not in c._render(data)
 
 
-# def test_get():
-#     c = _changelog(template="{{ version }}")
-#     c._collect_data = Mock(return_value={"version": "v1.2.3"})
-#     assert c.get("v1.2.3", "abc") == "v1.2.3"
-#     c._collect_data.assert_called_once_with("v1.2.3", "abc")
+def test_get():
+    c = _changelog(template="{{ version }}")
+    c._collect_data = Mock(return_value={"version": "v1.2.3"})
+    assert c.get("v1.2.3", "abc") == "v1.2.3"
+    c._collect_data.assert_called_once_with("v1.2.3", "abc")

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -367,7 +367,7 @@ def test_is_registered():
     # but I'm not really sure how it's possible.
 
 
-def test_new_versions():
+def test_new_package_versions():
     r = _repo()
     r._versions = (
         lambda min_age=None: {"1.2.3": "abc"}
@@ -375,7 +375,7 @@ def test_new_versions():
         else {"1.2.3": "abc", "3.4.5": "cde", "2.3.4": "bcd"}
     )
     r._filter_map_versions = lambda vs: vs
-    assert list(r.new_versions().items()) == [("2.3.4", "bcd"), ("3.4.5", "cde")]
+    assert list(r.new_package_versions().items()) == [("2.3.4", "bcd"), ("3.4.5", "cde")]
 
 
 def test_create_dispatch_event():

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -367,7 +367,7 @@ def test_is_registered():
     # but I'm not really sure how it's possible.
 
 
-def test_new_package_versions():
+def test_new_versions():
     r = _repo()
     r._versions = (
         lambda min_age=None: {"1.2.3": "abc"}
@@ -375,7 +375,7 @@ def test_new_package_versions():
         else {"1.2.3": "abc", "3.4.5": "cde", "2.3.4": "bcd"}
     )
     r._filter_map_versions = lambda vs: vs
-    assert list(r.new_package_versions().items()) == [("2.3.4", "bcd"), ("3.4.5", "cde")]
+    assert list(r.new_versions().items()) == [("2.3.4", "bcd"), ("3.4.5", "cde")]
 
 
 def test_create_dispatch_event():

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -34,7 +34,6 @@ def _repo(
     email="",
     lookback=3,
     branch=None,
-    subpackage="",
 ):
     return Repo(
         repo=repo,
@@ -52,7 +51,6 @@ def _repo(
         email=email,
         lookback=lookback,
         branch=branch,
-        subpackage="",
     )
 
 

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -511,7 +511,7 @@ def test_handle_release_branch():
     r._create_release_branch_pr.assert_called_with("v5", "release-5")
 
 
-def test_handle_release_branch_subpackage():
+def test_handle_release_branch_subdir():
     r = _repo(subdir="path/to/Foo.jl")
     r._repo.get_contents = Mock(
         return_value=Mock(decoded_content=b"""name = "Foo"\nuuid="abc-def"\n""")
@@ -583,7 +583,7 @@ def test_create_release():
     )
 
 
-def test_create_release_subpackage():
+def test_create_release_subdir():
     r = _repo(user="user", email="email", subdir="path/to/Foo.jl")
     r._commit_sha_of_release_branch = Mock(return_value="a")
     r._repo.get_contents = Mock(
@@ -681,10 +681,10 @@ def test_tag_prefix_and_get_version_tag():
     assert r._get_version_tag("v0.1.3") == "v0.1.3"
     assert r._get_version_tag("0.1.3") == "v0.1.3"
 
-    r_subpackage = _repo(subdir="FooBar")
-    r_subpackage._repo.get_contents = Mock(
+    r_subdir = _repo(subdir="FooBar")
+    r_subdir._repo.get_contents = Mock(
         return_value=Mock(decoded_content=b"""name = "FooBar"\nuuid="abc-def"\n""")
     )
-    assert r_subpackage._tag_prefix() == "FooBar-v"
-    assert r_subpackage._get_version_tag("v0.1.3") == "FooBar-v0.1.3"
-    assert r_subpackage._get_version_tag("0.1.3") == "FooBar-v0.1.3"
+    assert r_subdir._tag_prefix() == "FooBar-v"
+    assert r_subdir._get_version_tag("v0.1.3") == "FooBar-v0.1.3"
+    assert r_subdir._get_version_tag("0.1.3") == "FooBar-v0.1.3"

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -145,7 +145,10 @@ def test_create_release_branch_pr():
     r._repo = Mock(default_branch="default")
     r._create_release_branch_pr("Foo-v1.2.3", "branch")
     r._repo.create_pull.assert_called_once_with(
-        title="Merge release branch for Foo-v1.2.3", body="", head="branch", base="default"
+        title="Merge release branch for Foo-v1.2.3",
+        body="",
+        head="branch",
+        base="default",
     )
 
 

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -34,6 +34,7 @@ def _repo(
     email="",
     lookback=3,
     branch=None,
+    subpackage="",
 ):
     return Repo(
         repo=repo,
@@ -51,6 +52,7 @@ def _repo(
         email=email,
         lookback=lookback,
         branch=branch,
+        subpackage="",
     )
 
 


### PR DESCRIPTION
Closes #157.

I didn't directly follow [the last proposed approach](https://github.com/JuliaRegistries/TagBot/issues/157#issuecomment-805366788), namely "do a sweep in the registry for all packages with the same repo". Instead, I left the subpackage specification to the caller by adding an optional `subdir` input. In this way, a user can add a separate configuration blob per subpackage that they want to register. (Bonus: this terminology plays nicely with the monorepo support [currently in flight for Documenter.jl](https://github.com/JuliaDocs/Documenter.jl/pull/1993)). While the "register all subpackages" is potentially a follow-up use-case, this "register specific subpackages" approach is one that would suit my team's monorepo needs, and seems lean enough that it doesn't require a huge overhaul of this codebase (as was noted might be required in previous conversation).


Code review notes:
1. In `tagbot/action/changelog.py` especially, it looks like there are a lot of changes. In practice, a certain subset of these are _renaming_ rather than logic changes---I found that the `version` variable name was used for both the literal version of the package registered in the registry AND the value of the git tag added to a registered commit, so updated the latter to be named `version_tag`. (Previously, these were one and the same anyway; now, the clarity helped me understand how the two things interacted.)

3. fwiw, I struggled when adding tests due to unfamiliarity with this framework (both the mocking aspect and the Python aspect 😅). If folks have guidance for how to approach adding additional tests and/or suggestions for how to rewrite the ones I did add, I'm open!


----
Punch list: 
- [x] Understand where "version" means _tag_ version (aka `v3.2.1` or `MySubpackage-v3.2.1`, i.e. the version that the repo git tags know about) vs _package_ version (`3.2.1` regardless of top-level or subpackage, aka version that the _registry_ knows/cares about)
  - [x] Rename `version` vars that refer to version tags rather than package versions accordingly, for clarity
- [x] action: add new `subdir` input
  - [x] Plumb it through
- [x] local: add new  `subdir` input (no plumbing needed, uses same code as `action`
- [x] test - NOTE: I added some, but probably would benefit from more! See note.
  - [x] tests pass
- [x] Update documentation
- [x] lint pass 
- [x] open for review

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205338721197624