### PR TITLE
Provide git tag message via file for better handling

### DIFF
--- a/tagbot/action/git.py
+++ b/tagbot/action/git.py
@@ -2,7 +2,7 @@ import re
 import subprocess
 
 from datetime import datetime
-from tempfile import mkdtemp
+from tempfile import mkdtemp, mkstemp
 from typing import Optional, cast
 from urllib.parse import urlparse
 
@@ -103,7 +103,10 @@ class Git:
         self.config("user.email", self._email)
         # As mentioned in configure_gpg, we can't fully configure automatic signing.
         sign = ["--sign"] if self._gpgsign else []
-        self.command("tag", *sign, "-m", message, version, sha)
+        _, message_file = mkstemp()
+        with open(message_file, "w") as f:
+            f.write(message + "\n")
+        self.command("tag", *sign, "-F", message_file, version, sha)
         self.command("push", "origin", version)
 
     def fetch_branch(self, branch: str) -> bool:

--- a/test/action/test_git.py
+++ b/test/action/test_git.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, call, patch, ANY
 
 import pytest
 
@@ -103,7 +103,7 @@ def test_create_tag():
     ]
     g.config.assert_has_calls(calls)
     calls = [
-        call("tag", "-m", "log", "v1", "abcdef"),
+        call("tag", "-F", ANY, "v1", "abcdef"),
         call("push", "origin", "v1"),
     ]
     g.command.assert_has_calls(calls)


### PR DESCRIPTION
I've got a theory that the `git@github.com: Permission denied (publickey).` is a red herring and what's actually happening is unescaped chars in the tag message causing git to misunderstand the tag command TagBot is sending.

As an example, below is the debug output from a failed TagBot run which has a huge and complicated message to pass into -m, and it failed.

So this PR changes to pass the tag message via a file via the the `tag -F` arg.

I don't know how to test this. One option is if this passes we release it and see if it fixes it?

https://github.com/timholy/ProgressMeter.jl/actions/runs/5981657741/job/16230121798
```
##[debug]Running 'git -C /tmp/tagbot_repo_nkebbb74 tag -m ## ProgressMeter v1.8.0
##[debug]
##[debug][Diff since v1.7.2](https://github.com/timholy/ProgressMeter.jl/compare/v1.7.2...v1.8.0)
##[debug]
##[debug]## New Features
##[debug]
##[debug]- https://github.com/timholy/ProgressMeter.jl/pull/262 `@showprogress` now can take keyword arguments. For instance:
##[debug]```julia
##[debug]@showprogress "X: " color=:red showspeed=true for x in 1:10
##[debug]    sleep(1)
##[debug]end
##[debug]```
##[debug]or to dynamically disable the progress meter, for instance via an arg `show_progress`
##[debug]```julia
##[debug]@showprogress enabled=show_progress for x in 1:10
##[debug]    sleep(1)
##[debug]end
##[debug]```
##[debug]
##[debug]**Closed issues:**
##[debug]- Enabled keyword for macro @showprogress (#229)
##[debug]
##[debug]**Merged pull requests:**
##[debug]- Update README.md to account for signature change (#227) (@moyner)
##[debug]- Update README.md (#240) (@yakir12)
##[debug]- Structure docs more (#247) (@rikhuijzer)
##[debug]- Generalize CI check in tests. (#252) (@maleadt)
##[debug]- Add development/debugging tips on redirecting output to another terminal. (#257) (@fredrikekre)
##[debug]- Make @showprogress support keyword arguments (#262) (@dhanak)
##[debug]- enable dependabot for GitHub actions (#263) (@ranocha)
##[debug]- Bump actions/cache from 1 to 3 (#264) (@dependabot[bot])
##[debug]- Bump actions/checkout from 2 to 3 (#265) (@dependabot[bot])
##[debug]- Bump codecov/codecov-action from 1 to 3 (#266) (@dependabot[bot])
##[debug]- Missing unit "seconds" in doc string (#268) (@mschauer) v1.8.0 1ac7bbb3d342aeee835ae841e6712f494ff9bfff'
##[debug]Running 'git -C /tmp/tagbot_repo_nkebbb74 push origin v1.8.0'
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```