### PR TITLE
add a helpful perm warning to 403 errors

### DIFF
--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -606,7 +606,8 @@ class Repo:
                     """GitHub returned a 403 permissions-related error.
                     Please check that your ssh key and TagBot permissions are up to date
                     https://github.com/JuliaRegistries/TagBot#setup
-                    """)
+                    """
+                )
                 internal = False
         if not allowed:
             if internal:

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -590,7 +590,7 @@ class Repo:
     def handle_error(self, e: Exception) -> None:
         """Handle an unexpected error."""
         allowed = False
-        internal = False
+        internal = True
         trace = traceback.format_exc()
         if isinstance(e, RequestException):
             logger.warning("TagBot encountered a likely transient HTTP exception")

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -604,7 +604,7 @@ class Repo:
             elif e.status == 403:
                 logger.error(
                     """GitHub returned a 403 permissions-related error.
-                    Please check that your ssh key and permissions in the TagBot action are up to date
+                    Please check that your ssh key and TagBot permissions are up to date
                     https://github.com/JuliaRegistries/TagBot#setup
                     """)
                 internal = False

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -590,6 +590,7 @@ class Repo:
     def handle_error(self, e: Exception) -> None:
         """Handle an unexpected error."""
         allowed = False
+        internal = False
         trace = traceback.format_exc()
         if isinstance(e, RequestException):
             logger.warning("TagBot encountered a likely transient HTTP exception")
@@ -600,8 +601,16 @@ class Repo:
                 logger.warning("GitHub returned a 5xx error code")
                 logger.info(trace)
                 allowed = True
+            elif e.status == 403:
+                logger.error(
+                    """GitHub returned a 403 permissions-related error.
+                    Please check that your ssh key and permissions in the TagBot action are up to date
+                    https://github.com/JuliaRegistries/TagBot#setup
+                    """)
+                internal = False
         if not allowed:
-            logger.error("TagBot experienced an unexpected internal failure")
+            if internal:
+                logger.error("TagBot experienced an unexpected internal failure")
             logger.info(trace)
             try:
                 self._report_error(trace)


### PR DESCRIPTION
Looking at the only 3 error reports of [`Resource not accessible by integration`](https://github.com/JuliaRegistries/TagBotErrorReports/issues/101) since #264 they all were missing the new permissions. 

So this tries to give more targeted feedback to the user, without erroring.

If 403's turn out to be only tied to bad perms now perhaps this could be changed to a disallowed error and actually throw on the action. But that's premature.