### PR TITLE
Allow setting a tag prefix manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,26 @@ the action configuration should look something like
           subdir: path/to/SubpackageB.jl
 ```
 
-Generated tags will then be `v0.1.2` (top-level), `SubpackageA-v0.0.3`, and `SubpackageB-v2.3.1`.
+Generated tags will then be `v0.1.2` (top-level), `SubpackageA-v0.0.3`, and
+`SubpackageB-v2.3.1`. As an alternative to the automatic tag prefixing, you can manually
+specify a different tag prefix as an input:
+```yml
+    steps:
+      - name: Tag subpackage A
+        uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
+          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+          subdir: SubpackageA.jl
+          tag_prefix: MyOwnTagPrefix
+```
+In this case, the tag for SubpackageA.jl will be `MyOwnTagPrefix-v0.0.3`.
+
+If you want to disable tag prefixes for subdirectory packages altogether, you can set the
+`tag_prefix` to `NO_PREFIX`. Note that this is only recommended if you only have a single
+Julia package in the repository.
 
 **:information_source: Monorepo-specific changelog behavior**
   
@@ -457,6 +476,7 @@ Options:
   --changelog TEXT   Changelog template
   --registry TEXT    Registry to search
   --subdir TEXT      Subdirectory path in repo
+  --tag-prefix TEXT  Prefix for version tag
   --help             Show this message and exit.
 
 $ docker run --rm ghcr.io/juliaregistries/tagbot python -m tagbot.local \

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,9 @@ inputs:
   subdir:
     description: Subdirectory of package in repo, if not at top level
     required: false
+  tag_prefix:
+    description: Tag prefix (leave empty for automatic determination or set to `NO_PREFIX` to disable)
+    required: false
   changelog:
     description: Changelog template
     required: false

--- a/tagbot/action/__main__.py
+++ b/tagbot/action/__main__.py
@@ -63,6 +63,7 @@ try:
         lookback=int(get_input("lookback")),
         branch=get_input("branch"),
         subdir=get_input("subdir"),
+        tag_prefix=get_input("tag_prefix"),
     )
 
     if not repo.is_registered():

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -55,6 +55,7 @@ class Repo:
         lookback: int,
         branch: Optional[str],
         subdir: Optional[str] = None,
+        tag_prefix: Optional[str] = None,
         github_kwargs: Optional[Dict[str, object]] = None,
     ) -> None:
         if github_kwargs is None:
@@ -101,6 +102,7 @@ class Repo:
         self.__registry_clone_dir: Optional[str] = None
         self.__release_branch = branch
         self.__subdir = subdir
+        self.__tag_prefix = tag_prefix
         self.__project: Optional[MutableMapping[str, object]] = None
         self.__registry_path: Optional[str] = None
         self.__registry_url: Optional[str] = None
@@ -193,10 +195,17 @@ class Repo:
 
     def _tag_prefix(self) -> str:
         """Return the package's tag prefix."""
-        return self._project("name") + "-v" if self.__subdir else "v"
+        if self.__tag_prefix == "NO_PREFIX":
+            return "v"
+        elif self.__tag_prefix:
+            return self.__tag_prefix + "-v"
+        elif self.__subdir:
+            return self._project("name") + "-v"
+        else:
+            return "v"
 
     def _get_version_tag(self, package_version: str) -> str:
-        """Return the package-prefixed version tag."""
+        """Return the prefixed version tag."""
         if package_version.startswith("v"):
             package_version = package_version[1:]
         return self._tag_prefix() + package_version

--- a/tagbot/local/__main__.py
+++ b/tagbot/local/__main__.py
@@ -26,6 +26,7 @@ with (Path(__file__).parent.parent.parent / "action.yml").open() as f:
 @click.option("--registry", default=REGISTRY, help="Registry to search")
 @click.option("--draft", default=DRAFT, help="Create a draft release", is_flag=True)
 @click.option("--subdir", default=None, help="Subdirectory path in repo")
+@click.option("--tag-prefix", default=None, help="Prefix for version tag")
 def main(
     repo: str,
     version: str,
@@ -36,6 +37,7 @@ def main(
     registry: str,
     draft: bool,
     subdir: str,
+    tag_prefix: str,
 ) -> None:
     r = Repo(
         repo=repo,
@@ -54,6 +56,7 @@ def main(
         lookback=0,
         branch=None,
         subdir=subdir,
+        tag_prefix=tag_prefix,
     )
     version = version if version.startswith("v") else f"v{version}"
     sha = r.commit_sha_of_version(version)

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -35,6 +35,7 @@ def _repo(
     lookback=3,
     branch=None,
     subdir=None,
+    tag_prefix=None,
 ):
     return Repo(
         repo=repo,
@@ -53,6 +54,7 @@ def _repo(
         lookback=lookback,
         branch=branch,
         subdir=subdir,
+        tag_prefix=tag_prefix,
     )
 
 
@@ -710,3 +712,19 @@ def test_tag_prefix_and_get_version_tag():
     assert r_subdir._tag_prefix() == "FooBar-v"
     assert r_subdir._get_version_tag("v0.1.3") == "FooBar-v0.1.3"
     assert r_subdir._get_version_tag("0.1.3") == "FooBar-v0.1.3"
+
+    r_subdir = _repo(subdir="FooBar", tag_prefix="NO_PREFIX")
+    r_subdir._repo.get_contents = Mock(
+        return_value=Mock(decoded_content=b"""name = "FooBar"\nuuid="abc-def"\n""")
+    )
+    assert r._tag_prefix() == "v"
+    assert r._get_version_tag("v0.1.3") == "v0.1.3"
+    assert r._get_version_tag("0.1.3") == "v0.1.3"
+
+    r_subdir = _repo(tag_prefix="MyFooBar")
+    r_subdir._repo.get_contents = Mock(
+        return_value=Mock(decoded_content=b"""name = "FooBar"\nuuid="abc-def"\n""")
+    )
+    assert r_subdir._tag_prefix() == "MyFooBar-v"
+    assert r_subdir._get_version_tag("v0.1.3") == "MyFooBar-v0.1.3"
+    assert r_subdir._get_version_tag("0.1.3") == "MyFooBar-v0.1.3"


### PR DESCRIPTION
This PR enables users to manually specify a tag prefix, overriding the default tag prefix determination algorithm (the DTPDA, as it will henceforth be referred to as).

Before:
- `subdir=""`: tag prefix is `v`, e.g., `v0.1.0`
- `subdir="foo`": tag prefix is `foo-v`, e.g., `foo-v0.1.0`

With this PR, there are additional options available through the `tag_prefix` input:
- `tag_prefix=""` (default): as before
- `tag_prefix="bar"`: tag prefix is `bar-v`, e.g., `bar-v0.1.0` (whatever the content of `subdir`)
- `tag_prefix="NO_PREFIX"`: tag prefix is `v`, e.g., `v0.1.0` (whatever the content of `subdir`)

The main motivation is to allow users who have their Julia package in a subdirectory but want to tag their versions just as `v0.1.0` and not as `subdir-v0.1.0` to use TagBot (which is an awesome action, thanks a lot to all maintainers!). This should be a non-breaking change, since the DTPDA remains unchanged if the new action input `tag_prefix` is not set.

Resolves #278.

cc @bgeihe