### PR TITLE
Fix subdirectory tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ with:
 
 Version tags will then be prefixed with the subpackage's name: `{PACKAGE}-v{VERSION}`, e.g., `SubpackageName-v0.2.3`. (For top-level packages, the default tag is simply `v{VERSION}`.) 
 
+**Note**: Using TagBot with a non-empty `subdir` will only work for Julia package versions
+registered using the official
+[Registrator](https://github.com/JuliaRegistries/Registrator.jl) (see also
+[#281](https://github.com/JuliaRegistries/TagBot/issues/281) and
+[#282](https://github.com/JuliaRegistries/TagBot/pull/282)).
+
 To tag releases from a monorepo containing multiple subpackages and an optional top-level package, set up a separate step for each package you want to tag. For example, to tag all three packages in the following repository,
 
 ```

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -259,11 +259,13 @@ class Repo:
         # Handle special case of tagging packages in a repo subdirectory, in which
         # case the Julia package tree hash does not match the git commit tree hash
         if self.__subdir:
-            subdir_tree_hash = self._git.command("rev-parse", f"{commit.sha}:{self.__subdir}")
+            arg = f"{commit.sha}:{self.__subdir}"
+            subdir_tree_hash = self._git.command("rev-parse", arg)
             if subdir_tree_hash == tree:
                 return commit.sha
             else:
-                logger.warning("Subdir tree SHA of commit from registry PR does not match")
+                msg = "Subdir tree SHA of commit from registry PR does not match"
+                logger.warning(msg)
                 return None
         # Handle regular case (subdir is not set)
         if commit.commit.tree.sha == tree:

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -256,6 +256,16 @@ class Repo:
             logger.info("Registry PR body did not match")
             return None
         commit = self._repo.get_commit(m[1])
+        # Handle special case of tagging packages in a repo subdirectory, in which
+        # case the Julia package tree hash does not match the git commit tree hash
+        if self.__subdir:
+            subdir_tree_hash = self._git.command("rev-parse", f"{commit.sha}:{self.__subdir}")
+            if subdir_tree_hash == tree:
+                return commit.sha
+            else:
+                logger.warning("Subdir tree SHA of commit from registry PR does not match")
+                return None
+        # Handle regular case (subdir is not set)
         if commit.commit.tree.sha == tree:
             return commit.sha
         else:


### PR DESCRIPTION
Fixes #281.

Note that this uses the suggestion by @ericphanson in https://github.com/JuliaRegistries/TagBot/issues/281#issuecomment-1717640641 to proceed with tagging if the corresponding commit could be identified from the registry PR and if the subdirectory hash of that commit matches the Julia package version tree hash.

cc @bgeihe