### PR TITLE
Fix type mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       lookback:
-        default: 3
+        default: "3"
 permissions:
   actions: read
   checks: read

--- a/example.yml
+++ b/example.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       lookback:
-        default: 3
+        default: "3"
 permissions:
   actions: read
   checks: read


### PR DESCRIPTION
I noticed that number literal `3` is used where string is expected (see [here](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddefault) for detailed explanation).
This line is also highlighted as an error by [vscode-yaml](https://github.com/redhat-developer/vscode-yaml) extension, with the following message:
> Unexpected type 'NumberToken' encountered while reading 'input default'. The type 'StringToken' was expected.
