### PR TITLE
Always create tags via CLI

### DIFF
--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -19,7 +19,7 @@ from tempfile import mkdtemp, mkstemp
 from typing import Dict, List, Mapping, MutableMapping, Optional, TypeVar, Union, cast
 from urllib.parse import urlparse
 
-from github import Github, GithubException, InputGitAuthor, UnknownObjectException
+from github import Github, GithubException, UnknownObjectException
 from github.PullRequest import PullRequest
 from gnupg import GPG
 from semver import VersionInfo

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -590,19 +590,11 @@ class Repo:
         logger.debug(f"Release {version_tag} target: {target}")
         log = self._changelog.get(version_tag, sha)
         if not self._draft:
-            if self._ssh or self._gpg:
-                logger.debug("Creating tag via Git CLI")
-                self._git.create_tag(version_tag, sha, log)
-            else:
-                logger.debug("Creating tag via GitHub API")
-                tag = self._repo.create_git_tag(
-                    version_tag,
-                    log,
-                    sha,
-                    "commit",
-                    tagger=InputGitAuthor(self._user, self._email),
-                )
-                self._repo.create_git_ref(f"refs/tags/{version_tag}", tag.sha)
+            # Always create tags via the CLI as the GitHub API has a bug which
+            # only allows tags to be created for SHAs which are the the HEAD
+            # commit on a branch.
+            # https://github.com/JuliaRegistries/TagBot/issues/239#issuecomment-2246021651
+            self._git.create_tag(version_tag, sha, log)
         logger.info(f"Creating release {version_tag} at {sha}")
         self._repo.create_git_release(
             version_tag, version_tag, log, target_commitish=target, draft=self._draft

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -571,19 +571,7 @@ def test_create_release():
     r._repo.create_git_tag.return_value.sha = "t"
     r._changelog.get = Mock(return_value="l")
     r.create_release("v1", "a")
-    r._git.create_tag.assert_not_called()
-    # InputGitAuthor doesn't support equality so we can't use a normal
-    # assert_called_with here.
-    r._repo.create_git_tag.assert_called_once()
-    call = r._repo.create_git_tag.mock_calls[0]
-    assert call.args == ("v1", "l", "a", "commit")
-    assert len(call.kwargs) == 1 and "tagger" in call.kwargs
-    tagger = call.kwargs["tagger"]
-    assert isinstance(tagger, InputGitAuthor) and tagger._identity == {
-        "name": "user",
-        "email": "email",
-    }
-    r._repo.create_git_ref.assert_called_with("refs/tags/v1", "t")
+    r._git.create_tag.assert_called_with("v1", "a", "l")
     r._repo.create_git_release.assert_called_with(
         "v1", "v1", "l", target_commitish="default", draft=False
     )
@@ -591,17 +579,12 @@ def test_create_release():
     r._repo.create_git_release.assert_called_with(
         "v1", "v1", "l", target_commitish="b", draft=False
     )
-    r._ssh = True
     r.create_release("v1", "c")
     r._git.create_tag.assert_called_with("v1", "c", "l")
     r._draft = True
     r._git.create_tag.reset_mock()
-    r._repo.create_git_tag.reset_mock()
-    r._repo.create_git_ref.reset_mock()
     r.create_release("v1", "d")
     r._git.create_tag.assert_not_called()
-    r._repo.create_git_tag.assert_not_called()
-    r._repo.create_git_ref.assert_not_called()
     r._repo.create_git_release.assert_called_with(
         "v1", "v1", "l", target_commitish="d", draft=True
     )

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -602,7 +602,7 @@ def test_create_release_subdir():
     r._repo.create_git_tag.return_value.sha = "t"
     r._changelog.get = Mock(return_value="l")
     r.create_release("v1", "a")
-    r._git.create_tag.assert_called_with("v1", "a", "l")
+    r._git.create_tag.assert_called_with("Foo-v1", "a", "l")
     r._repo.create_git_release.assert_called_with(
         "Foo-v1", "Foo-v1", "l", target_commitish="default", draft=False
     )

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -602,19 +602,7 @@ def test_create_release_subdir():
     r._repo.create_git_tag.return_value.sha = "t"
     r._changelog.get = Mock(return_value="l")
     r.create_release("v1", "a")
-    r._git.create_tag.assert_not_called()
-    # InputGitAuthor doesn't support equality so we can't use a normal
-    # assert_called_with here.
-    r._repo.create_git_tag.assert_called_once()
-    call = r._repo.create_git_tag.mock_calls[0]
-    assert call.args == ("Foo-v1", "l", "a", "commit")
-    assert len(call.kwargs) == 1 and "tagger" in call.kwargs
-    tagger = call.kwargs["tagger"]
-    assert isinstance(tagger, InputGitAuthor) and tagger._identity == {
-        "name": "user",
-        "email": "email",
-    }
-    r._repo.create_git_ref.assert_called_with("refs/tags/Foo-v1", "t")
+    r._git.create_tag.assert_called_with("v1", "a", "l")
     r._repo.create_git_release.assert_called_with(
         "Foo-v1", "Foo-v1", "l", target_commitish="default", draft=False
     )
@@ -622,17 +610,12 @@ def test_create_release_subdir():
     r._repo.create_git_release.assert_called_with(
         "Foo-v1", "Foo-v1", "l", target_commitish="b", draft=False
     )
-    r._ssh = True
     r.create_release("v1", "c")
     r._git.create_tag.assert_called_with("Foo-v1", "c", "l")
     r._draft = True
     r._git.create_tag.reset_mock()
-    r._repo.create_git_tag.reset_mock()
-    r._repo.create_git_ref.reset_mock()
     r.create_release("v1", "d")
     r._git.create_tag.assert_not_called()
-    r._repo.create_git_tag.assert_not_called()
-    r._repo.create_git_ref.assert_not_called()
     r._repo.create_git_release.assert_called_with(
         "Foo-v1", "Foo-v1", "l", target_commitish="d", draft=True
     )

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, call, mock_open, patch
 
 import pytest
 
-from github import GithubException, InputGitAuthor, UnknownObjectException
+from github import GithubException, UnknownObjectException
 from github.Requester import requests
 
 from tagbot.action import TAGBOT_WEB, Abort, InvalidProject


### PR DESCRIPTION
Fixes #239. There is a bug with the GitHub API where you can only create tags for SHA's which are the `HEAD` commit on a branch (https://github.com/orgs/community/discussions/68932). Attempting to register tags for other SHAs results in failures like this: https://github.com/JuliaRegistries/TagBot/issues/239#issuecomment-2246021651