### PR TITLE
Try fixing #350

### DIFF
--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -156,16 +156,9 @@ class Repo:
                 registry = toml.load(f)
         else:
             contents = self._only(self._registry.get_contents("Registry.toml"))
-            # show file contents if cannot be decoded
-            try:
-                string_contents = contents.decoded_content.decode()
-            except AssertionError:
-                logger.info(
-                    f"Registry.toml could not be decoded. Raw contents: {contents}"
-                )
-                # rethrow now we've logged info
-                raise
-
+            blob = self._registry.get_git_blob(contents.sha)
+            b64 = b64decode(blob.content)
+            string_contents = b64.decode("utf8")
             registry = toml.loads(string_contents)
 
         if uuid in registry["packages"]:

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -102,10 +102,12 @@ def test_registry_path():
     r = _repo()
     r._registry = Mock()
     r._registry.get_contents.return_value.sha = "123"
-    r._registry.get_git_blob.return_value.content = b64encode(b"""
-    [packages]
-    abc-def = { path = "B/Bar" }
-    """)
+    r._registry.get_git_blob.return_value.content = b64encode(
+        b"""
+        [packages]
+        abc-def = { path = "B/Bar" }
+        """
+    )
     r._project = lambda _k: "abc-ddd"
     assert r._registry_path is None
     r._project = lambda _k: "abc-def"

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -101,10 +101,11 @@ def test_project_subdir():
 def test_registry_path():
     r = _repo()
     r._registry = Mock()
-    r._registry.get_contents.return_value.decoded_content = b"""
+    r._registry.get_contents.return_value.sha = "123"
+    r._registry.get_git_blob.return_value.content = b64encode(b"""
     [packages]
     abc-def = { path = "B/Bar" }
-    """
+    """)
     r._project = lambda _k: "abc-ddd"
     assert r._registry_path is None
     r._project = lambda _k: "abc-def"


### PR DESCRIPTION
!!! This is untested!

This is according to https://github.com/PyGithub/PyGithub/issues/2345#issuecomment-1835376705

Locally I tested that the following works correctly:

```python
In [24]: from github import Github, Auth

In [25]: auth = Auth.Token(token)

In [26]: g = Github(auth=auth)

In [27]: repo = g.get_repo("JuliaRegistries/General")

In [28]: registry_toml = repo.get_contents("Registry.toml")

In [39]: blob = repo.get_git_blob(registry_toml.sha)

In [40]: b64 = base64.b64decode(blob.content)

In [41]: b64.decode("utf8")
```