### PR TITLE
Unbreak recommended TagBot workflow

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -7,19 +7,6 @@ on:
     inputs:
       lookback:
         default: "3"
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/README.md
+++ b/README.md
@@ -23,19 +23,6 @@ on:
     inputs:
       lookback:
         default: "3"
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'

--- a/example.yml
+++ b/example.yml
@@ -7,19 +7,6 @@ on:
     inputs:
       lookback:
         default: "3"
-permissions:
-  actions: read
-  checks: read
-  contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Using these permissions renders TagBot inoperable.

It may be that GitHub just changed something and one just needs to add one more or so, but I couldn't figure this out, and everything works w/o these, and doesn't with these, even when following the setup instructions to the letter and in every detail.

Resolves #388 (see there for details).

Resolves #384