### PR TITLE
Allow TagBot to handle Copilot PRs

### DIFF
--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -183,8 +183,15 @@ class Changelog:
     def _format_user(self, user: Optional[NamedUser]) -> Dict[str, object]:
         """Format a user for the template."""
         if user:
+            # Fetching `user.name` for the Copilot bot fails, so it needs to be
+            # special-cased.
+            name = (
+                "Copilot"
+                if (user.login == "Copilot" and user.type == "Bot")
+                else (user.name or user.login)
+            )
             return {
-                "name": user.name or user.login,
+                "name": name,
                 "url": user.html_url,
                 "username": user.login,
             }


### PR DESCRIPTION
This line fails when the user is the special GitHub copilot bot, meaning that TagBot will always error if Copilot has had a PR in a repo merged. Specifically, fetching `user.name` ultimately leads to the PyGithub library querying https://api.github.com/users/Copilot which throws a 404 error.

https://github.com/JuliaRegistries/TagBot/blob/2923435e255dc15230570ba3b5393e97dbf6c3a6/tagbot/action/changelog.py#L187

This PR fixes it. An example of a release created with this patch of TagBot (I ran it locally) can be found at https://github.com/TuringLang/AbstractPPL.jl/releases/tag/v0.13.1.

I'm unsure why CI is failing, but it seems rather unrelated to this PR.