### PR TITLE
Fix failing test_constuctor test by properly mocking GitHub API calls

### DIFF
--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -59,7 +59,7 @@ def _repo(
 
 
 @patch("tagbot.action.repo.Github")
-def test_constuctor(mock_github):
+def test_constructor(mock_github):
     # Mock the Github instance and its get_repo method
     mock_gh_instance = Mock()
     mock_github.return_value = mock_gh_instance

--- a/test/action/test_repo.py
+++ b/test/action/test_repo.py
@@ -58,12 +58,25 @@ def _repo(
     )
 
 
-def test_constuctor():
-    r = _repo(github="github.com", github_api="api.github.com")
+@patch("tagbot.action.repo.Github")
+def test_constuctor(mock_github):
+    # Mock the Github instance and its get_repo method
+    mock_gh_instance = Mock()
+    mock_github.return_value = mock_gh_instance
+    mock_gh_instance.get_repo.return_value = Mock()  # Mock registry repo
+
+    r = _repo(
+        github="github.com", github_api="api.github.com", registry="test/registry"
+    )
     assert r._gh_url == "https://github.com"
     assert r._gh_api == "https://api.github.com"
     assert r._git._github == "github.com"
-    r = _repo(github="https://github.com", github_api="https://api.github.com")
+
+    r = _repo(
+        github="https://github.com",
+        github_api="https://api.github.com",
+        registry="test/registry",
+    )
     assert r._gh_url == "https://github.com"
     assert r._gh_api == "https://api.github.com"
     assert r._git._github == "github.com"


### PR DESCRIPTION
## Problem
The test_constuctor test was failing with tagbot.action.Abort: Registry is not accessible because it was trying to create a Repo object with an empty registry parameter, causing real GitHub API calls to fail during object construction.

## Solution
Fixed the test by properly mocking the GitHub API dependencies:

Added `@patch("tagbot.action.repo.Github")` to mock the GitHub client during object construction Provided a valid test registry name ("test/registry") instead of empty string Mocked the get_repo() method to return a valid mock object


Written by Claude