### PR TITLE
Fix: Continue processing versions when one fails

### DIFF
--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -673,7 +673,7 @@ class Repo:
         except Exception as e:
             logger.debug(f"Could not check rate limit: {e}")
 
-    def handle_error(self, e: Exception) -> None:
+    def handle_error(self, e: Exception, *, raise_abort: bool = True) -> None:
         """Handle an unexpected error."""
         allowed = False
         internal = True
@@ -707,7 +707,7 @@ class Repo:
             except Exception:
                 logger.error("Issue reporting failed")
                 logger.info(traceback.format_exc())
-            finally:
+            if raise_abort:
                 raise Abort("Cannot continue due to internal failure")
 
     def commit_sha_of_version(self, version: str) -> Optional[str]:


### PR DESCRIPTION
When multiple versions need to be released, TagBot now continues processing remaining versions even if one fails, instead of aborting the entire run. Errors are collected and reported at the end.

Fixes #304