### PR TITLE
Fix: Strip whitespace from keys before base64 decoding

### DIFF
--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -234,6 +234,7 @@ class Repo:
 
     def _maybe_decode_private_key(self, key: str) -> str:
         """Return a decoded value if it is Base64-encoded, or the original value."""
+        key = key.strip()
         return key if "PRIVATE KEY" in key else b64decode(key).decode()
 
     def _create_release_branch_pr(self, version_tag: str, branch: str) -> None:


### PR DESCRIPTION
Prevents base64 padding errors caused by extra whitespace/newlines at the end of GPG or SSH keys stored in secrets.

Fixes #211