### PR TITLE
Put patch first in publish workflow, auto-generate release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,9 @@ on:
         required: true
         description: What kind of bump
         options:
-        - major
-        - minor
         - patch
+        - minor
+        - major
   pull_request:
     types:
       - closed

--- a/bin/publish.py
+++ b/bin/publish.py
@@ -141,6 +141,7 @@ def create_release(repo: Repository, pr: PullRequest) -> None:
             name=release,
             message=notes,
             target_commitish=pr.merge_commit_sha,
+            generate_release_notes=True,
         )
     except GithubException as e:
         if e.status == 422:


### PR DESCRIPTION
Just tweaks to the tag & release process for TagBot itself 

- Reorder version bump options: patch, minor, major
- Enable GitHub's auto-generated release notes