### PR TITLE
fix: redact token from error reports

### DIFF
--- a/tagbot/action/git.py
+++ b/tagbot/action/git.py
@@ -51,6 +51,12 @@ class Git:
             self.__default_branch = branch
         return branch
 
+    def _sanitize_command(self, cmd: str) -> str:
+        """Remove sensitive tokens from command strings."""
+        if self._token:
+            cmd = cmd.replace(self._token, "***")
+        return cmd
+
     def command(self, *argv: str, repo: Optional[str] = "") -> str:
         """Run a Git command."""
         args = ["git"]
@@ -60,15 +66,15 @@ class Git:
             args.extend(["-C", repo or self._dir])
         args.extend(argv)
         cmd = " ".join(args)
-        logger.debug(f"Running '{cmd}'")
+        logger.debug(f"Running '{self._sanitize_command(cmd)}'")
         proc = subprocess.run(args, text=True, capture_output=True)
         out = proc.stdout.strip()
         if proc.returncode:
             if out:
-                logger.info(out)
+                logger.info(self._sanitize_command(out))
             if proc.stderr:
-                logger.info(proc.stderr.strip())
-            raise Abort(f"Git command '{cmd}' failed")
+                logger.info(self._sanitize_command(proc.stderr.strip()))
+            raise Abort(f"Git command '{self._sanitize_command(cmd)}' failed")
         return out
 
     def check(self, *argv: str, repo: Optional[str] = "") -> bool:

--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -155,6 +155,12 @@ class Repo:
         self.__registry_path: Optional[str] = None
         self.__registry_url: Optional[str] = None
 
+    def _sanitize(self, text: str) -> str:
+        """Remove sensitive tokens from text."""
+        if self._token:
+            text = text.replace(self._token, "***")
+        return text
+
     def _project(self, k: str) -> str:
         """Get a value from the Project.toml."""
         if self.__project is not None:
@@ -661,7 +667,7 @@ class Repo:
                 )
 
         versions_list = "\n".join(
-            f"- [ ] `{v}` at commit `{sha[:8]}`\n  - Error: {err}"
+            f"- [ ] `{v}` at commit `{sha[:8]}`\n  - Error: {self._sanitize(err)}"
             for v, sha, err in failures
         )
         pat_url = (
@@ -913,7 +919,7 @@ See [TagBot troubleshooting]({troubleshoot_url}) for details.
         """Handle an unexpected error."""
         allowed = False
         internal = True
-        trace = traceback.format_exc()
+        trace = self._sanitize(traceback.format_exc())
         if isinstance(e, Abort):
             # Abort is raised for characterized failures (e.g., git command failures)
             # Don't report as "unexpected internal failure"


### PR DESCRIPTION
## Sanitize tokens from error messages and logs

### Problem

Error reports submitted to JuliaRegistries/TagBotErrorReports can leak GitHub API tokens. When a git command fails, the error message includes the full command string containing the authentication URL with the token embedded:

```
https://oauth2:ghs_...@github.com/Owner/Repo
```

This token appears in:
- Log output
- The `Abort` exception message
- Stacktraces sent to the public error reporting service
- GitHub issues created for manual intervention

See: https://github.com/JuliaRegistries/TagBotErrorReports/issues/157

### Solution

Add sanitization methods that replace tokens with `***` before any text is logged or reported:

- `Git._sanitize_command()` - sanitizes git commands and their output
- `Repo._sanitize()` - sanitizes stacktraces and error messages

Applied sanitization to:
- Debug logs showing git commands being run
- Error logs showing git stdout/stderr on failure
- `Abort` exception messages from failed git commands
- Stacktraces in `handle_error()` before logging or sending to error reporting
- Error messages included in GitHub issues for manual intervention

### Impact Assessment

The token leaked in issue #157 (`ghs_xxx`) is a **GitHub App installation access token** which:
- Is automatically generated per-workflow-run
- Has a short lifespan (~1 hour)
- Is scoped only to the repository where the action ran
- Has already expired

No credential cycling is required, but the error report issue should be deleted for hygiene.