### PR TITLE
Use get_git_matching_refs for faster server-side tag filtering

### DIFF
--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -595,11 +595,9 @@ class Repo:
         for attempt in range(retries):
             try:
                 _metrics.api_calls += 1
-                # Fetch all tag refs in one paginated call
-                refs = self._repo.get_git_refs()
+                # Fetch only tag refs using server-side filtering (much faster)
+                refs = self._repo.get_git_matching_refs("tags/")
                 for ref in refs:
-                    if not ref.ref.startswith("refs/tags/"):
-                        continue
                     tags_prefix_len = len("refs/tags/")
                     tag_name = ref.ref[tags_prefix_len:]
                     ref_type = getattr(ref.object, "type", None)


### PR DESCRIPTION
- Switch from get_git_refs() to get_git_matching_refs('tags/') in _build_tags_cache
- This filters tags server-side, avoiding fetching all refs (branches, etc.)
- Remove client-side refs/tags/ prefix check since API now only returns tags
- Update tests to use get_git_matching_refs mock