### PR TITLE
Fix slow tag checking and tree lookups for non-PR registries

### DIFF
--- a/tagbot/action/repo.py
+++ b/tagbot/action/repo.py
@@ -517,25 +517,6 @@ class Repo:
             logger.warning("Tree SHA of commit from registry PR does not match")
             return None
 
-    def _commit_sha_of_tree_from_branch(
-        self, branch: str, tree: str, since: Optional[datetime] = None
-    ) -> Optional[str]:
-        """Look up the commit SHA of a tree with the given SHA on one branch."""
-        kwargs: Dict[str, object] = {"sha": branch}
-        if since is not None:
-            kwargs["since"] = since
-        for commit in self._repo.get_commits(**kwargs):
-            if self.__subdir:
-                subdir_tree_hash = self._subdir_tree_hash(
-                    commit.sha, suppress_abort=True
-                )
-                if subdir_tree_hash == tree:
-                    return cast(str, commit.sha)
-            else:
-                if commit.commit.tree.sha == tree:
-                    return cast(str, commit.sha)
-        return None
-
     def _build_tree_to_commit_cache(self) -> Dict[str, str]:
         """Build a cache mapping tree SHAs to commit SHAs.
 


### PR DESCRIPTION
### Problem

TagBot was experiencing severe performance issues:
1. **Annotated tag resolution**: For repos with many existing tags, `_commit_sha_of_tag()` was called per-version, resolving every annotated tag via an API call (e.g., 625 API calls for 625 versions)
2. **Tree lookup for non-PR registries**: Custom registries without JuliaRegistrator PRs fell back to `_commit_sha_of_tree()`, which iterates O(branches × commits) via API calls

### Solution

1. **Dict lookup for tag existence**: Check `version_tag in tags_cache` (O(1)) instead of calling `_commit_sha_of_tag()` which resolves annotated tags

2. **Tree→commit cache**: Build a cache using `git log --all --format=%H %T` once, then do O(1) lookups instead of iterating through commits via API

### Performance Impact

| Scenario | Before | After |
|----------|--------|-------|
| All tags exist (625 versions, annotated) | ~282s, 625+ API calls | ~few seconds, 1 API call |
| Non-PR registry, new versions | O(branches × commits) API calls per version | Single `git log` + O(1) lookups |

### Changes

- Check tag existence via dict lookup instead of calling `_commit_sha_of_tag()`
- Add `_build_tree_to_commit_cache()` using `git log --all --format=%H %T`
- Replace `_commit_sha_of_tree()` implementation with cache-based O(1) lookup
- Lazy PR cache loading (only built when first version needs registry PR lookup)
- Add debug logging for tree lookup fallback