### PR TITLE
Fix: skip release creation if release for tag already exists

### DIFF
--- a/test/action/test_backfilling.py
+++ b/test/action/test_backfilling.py
@@ -309,6 +309,7 @@ def test_create_release_with_is_latest(logger):
 
     r._repo = Mock()
     r._repo.default_branch = "main"
+    r._repo.get_releases = Mock(return_value=[])
     r._changelog = Mock()
     r._changelog.get = Mock(return_value="Changelog content")
     r._git = Mock()


### PR DESCRIPTION
[Looks into TagbotError](https://github.com/JuliaRegistries/TagBotErrorReports/issues/159)