### PR TITLE
Include pyproject.toml in Lambda package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ build-ApiFunction build-ReportsFunction:
 		--platform manylinux2014_x86_64 --only-binary=:all: \
 		--python-version 3.12 --implementation cp
 	cp -r tagbot $(ARTIFACTS_DIR)/
+	cp pyproject.toml $(ARTIFACTS_DIR)/
 
 test:
 	./bin/test.sh


### PR DESCRIPTION
Fixes version display on julia-tagbot.com showing "dev" instead of the actual version. The web app reads the version from pyproject.toml but it wasn't being copied to the Lambda artifact directory.