### PR TITLE
Verify workflow runs before filing error reports

### DIFF
--- a/tagbot/web/reports.py
+++ b/tagbot/web/reports.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 
 import boto3
 
-from github import Github
+from github import Github, GithubException
 from github.Issue import Issue
 from github.IssueComment import IssueComment
 from github.Repository import Repository
@@ -36,6 +36,55 @@ def _get_issues_repo() -> Repository:
     return _get_gh().get_repo(TAGBOT_ISSUES_REPO_NAME, lazy=True)
 
 
+_RUN_URL_RE = re.compile(
+    r"^https://github\.com/(?P<repo>[^/]+/[^/]+)/actions/runs/(?P<run_id>\d+)"
+)
+
+# Workflow run statuses that indicate the run is still active. Reports are sent
+# while TagBot is mid-run, so a legitimate report's run is never yet completed.
+_ACTIVE_RUN_STATUSES = {"queued", "in_progress", "requested", "waiting", "pending"}
+
+
+def _verify_run(repo: str, run: str) -> bool:
+    """Verify that a report corresponds to a real, active TagBot run.
+
+    The client only reports public repositories running in GitHub Actions, so the
+    web service can independently confirm each report using its own GitHub token:
+    it looks up the workflow run named in the report and checks that the run
+    belongs to the claimed repository and is still active.
+
+    Fails closed: if the run cannot be positively confirmed (private repo,
+    nonexistent repo, mismatched or completed run, API error), the report is
+    rejected. Private-repo runs are invisible to the token and never reported by
+    the client, so they correctly never reach this point.
+    """
+    m = _RUN_URL_RE.match(run or "")
+    if not m:
+        logger.warning("Run URL did not match the expected format; rejecting")
+        return False
+    if m["repo"].casefold() != repo.casefold():
+        logger.warning("Run URL repo does not match the reported repo; rejecting")
+        return False
+    run_id = int(m["run_id"])
+    try:
+        wf_run = _get_gh().get_repo(repo, lazy=True).get_workflow_run(run_id)
+        full_name = wf_run.repository.full_name
+        status = wf_run.status
+    except GithubException as e:
+        logger.warning(f"Could not verify workflow run (status {e.status}); rejecting")
+        return False
+    except Exception:
+        logger.warning("Unexpected error verifying workflow run; rejecting")
+        return False
+    if not full_name or full_name.casefold() != repo.casefold():
+        logger.warning("Workflow run repository mismatch; rejecting")
+        return False
+    if status not in _ACTIVE_RUN_STATUSES:
+        logger.warning(f"Workflow run is not active (status {status}); rejecting")
+        return False
+    return True
+
+
 def handler(event: Dict[str, str], ctx: object = None) -> None:
     """Lambda event handler."""
     logger.info(f"Event: {json.dumps(event, indent=2)}")
@@ -59,6 +108,9 @@ def _handle_report(
     manual_intervention_url: Optional[str] = None,
 ) -> None:
     """Report an error."""
+    if not _verify_run(repo, run):
+        logger.warning(f"Rejecting unverifiable report for {repo}")
+        return
     duplicate = _find_duplicate(stacktrace)
     if duplicate and duplicate.state == "open":
         logger.info(f"Found a duplicate (#{duplicate.number})")

--- a/test/web/test_reports.py
+++ b/test/web/test_reports.py
@@ -1,6 +1,8 @@
 from textwrap import dedent
 from unittest.mock import Mock, patch
 
+from github import GithubException
+
 from tagbot.web import reports
 
 
@@ -36,12 +38,13 @@ def test_handler(handle_report):
     )
 
 
+@patch("tagbot.web.reports._verify_run", return_value=True)
 @patch("tagbot.web.reports._find_duplicate", return_value=None)
 @patch("tagbot.web.reports._already_commented", side_effect=[True, False])
 @patch("tagbot.web.reports._add_duplicate_comment")
 @patch("tagbot.web.reports._create_issue", return_value=Mock(html_url="new"))
 def test_handle_report(
-    create_issue, add_duplicate_comment, already_commented, find_duplicate
+    create_issue, add_duplicate_comment, already_commented, find_duplicate, verify_run
 ):
     kwargs = {"image": "img", "repo": "Foo/Bar", "run": "123", "stacktrace": "ow"}
     reports._handle_report(**kwargs)
@@ -53,11 +56,12 @@ def test_handle_report(
     add_duplicate_comment.assert_called()
 
 
+@patch("tagbot.web.reports._verify_run", return_value=True)
 @patch("tagbot.web.reports._find_duplicate")
 @patch("tagbot.web.reports._add_duplicate_comment")
 @patch("tagbot.web.reports._create_issue", return_value=Mock(html_url="new"))
 def test_handle_report_closed_duplicate_creates_new_issue(
-    create_issue, add_duplicate_comment, find_duplicate
+    create_issue, add_duplicate_comment, find_duplicate, verify_run
 ):
     find_duplicate.return_value = Mock(
         number=42, state="closed", html_url="https://github.com/org/repo/issues/42"
@@ -73,9 +77,10 @@ def test_handle_report_closed_duplicate_creates_new_issue(
     )
 
 
+@patch("tagbot.web.reports._verify_run", return_value=True)
 @patch("tagbot.web.reports._find_duplicate", return_value=None)
 @patch("tagbot.web.reports._create_issue", return_value=Mock(html_url="new"))
-def test_handle_report_with_extras(create_issue, find_duplicate):
+def test_handle_report_with_extras(create_issue, find_duplicate, verify_run):
     kwargs = {
         "image": "img",
         "repo": "Foo/Bar",
@@ -86,6 +91,72 @@ def test_handle_report_with_extras(create_issue, find_duplicate):
     }
     reports._handle_report(**kwargs)
     create_issue.assert_called_with(**kwargs, closed_duplicate_url=None)
+
+
+@patch("tagbot.web.reports._verify_run", return_value=False)
+@patch("tagbot.web.reports._find_duplicate")
+@patch("tagbot.web.reports._create_issue")
+def test_handle_report_rejects_unverifiable(create_issue, find_duplicate, verify_run):
+    kwargs = {"image": "img", "repo": "Foo/Bar", "run": "123", "stacktrace": "ow"}
+    reports._handle_report(**kwargs)
+    verify_run.assert_called_with("Foo/Bar", "123")
+    find_duplicate.assert_not_called()
+    create_issue.assert_not_called()
+
+
+RUN_URL = "https://github.com/Foo/Bar/actions/runs/123"
+
+
+@patch("tagbot.web.reports._get_gh")
+def test_verify_run(_get_gh):
+    wf_run = _get_gh.return_value.get_repo.return_value.get_workflow_run.return_value
+    wf_run.repository.full_name = "Foo/Bar"
+    wf_run.status = "in_progress"
+    assert reports._verify_run("Foo/Bar", RUN_URL)
+    # Case-insensitive repo matching.
+    assert reports._verify_run("foo/bar", RUN_URL)
+
+
+def test_verify_run_bad_url():
+    assert not reports._verify_run("Foo/Bar", "")
+    assert not reports._verify_run("Foo/Bar", "https://example.com")
+    assert not reports._verify_run("Foo/Bar", "Foo/Bar/actions")
+
+
+def test_verify_run_url_repo_mismatch():
+    assert not reports._verify_run("Other/Repo", RUN_URL)
+
+
+@patch("tagbot.web.reports._get_gh")
+def test_verify_run_repository_mismatch(_get_gh):
+    wf_run = _get_gh.return_value.get_repo.return_value.get_workflow_run.return_value
+    wf_run.repository.full_name = "Evil/Repo"
+    wf_run.status = "in_progress"
+    assert not reports._verify_run("Foo/Bar", RUN_URL)
+
+
+@patch("tagbot.web.reports._get_gh")
+def test_verify_run_not_active(_get_gh):
+    wf_run = _get_gh.return_value.get_repo.return_value.get_workflow_run.return_value
+    wf_run.repository.full_name = "Foo/Bar"
+    wf_run.status = "completed"
+    assert not reports._verify_run("Foo/Bar", RUN_URL)
+
+
+@patch("tagbot.web.reports._get_gh")
+def test_verify_run_github_exception(_get_gh):
+    _get_gh.return_value.get_repo.return_value.get_workflow_run.side_effect = (
+        GithubException(404, "Not Found", None)
+    )
+    assert not reports._verify_run("Foo/Bar", RUN_URL)
+
+
+@patch("tagbot.web.reports._get_gh")
+def test_verify_run_unexpected_error(_get_gh):
+    _get_gh.return_value.get_repo.return_value.get_workflow_run.side_effect = (
+        RuntimeError("boom")
+    )
+    assert not reports._verify_run("Foo/Bar", RUN_URL)
 
 
 def test_already_commented():


### PR DESCRIPTION
Addressing poking someone is doing
https://github.com/JuliaRegistries/TagBotErrorReports/issues/255
https://github.com/JuliaRegistries/TagBotErrorReports/issues/254
https://github.com/JuliaRegistries/TagBotErrorReports/issues/253
https://github.com/JuliaRegistries/TagBotErrorReports/issues/231


Claude:

---

The /report endpoint is public and unauthenticated, so anyone could POST arbitrary payloads and have TagBot file issues in TagBotErrorReports (observed: hand-crafted test reports with fake repos/tracebacks).

Add server-side run verification in the reports Lambda: parse the repo and run ID from the report's run URL and confirm, using the web service's own GitHub token, that the workflow run exists, belongs to the claimed repo, and is still active. Fails closed on any mismatch, missing/completed run, or API error. This requires no changes to user workflows and keeps private repos out of scope on both ends (the client never reports them, and the token cannot see them).

GitLab reports are dropped by this check, which is acceptable: their run URLs were already non-functional and are unverifiable with a GitHub token.