### PR TITLE
Throttle /report and invoke reports Lambda asynchronously

### DIFF
--- a/stubs/boto3.pyi
+++ b/stubs/boto3.pyi
@@ -1,7 +1,9 @@
 from typing import Any, Dict, Literal, Union, overload
 
 class Lambda:
-    def invoke(self, *, FunctionName: str, Payload: str) -> object: ...
+    def invoke(
+        self, *, FunctionName: str, Payload: str, InvocationType: str = ...
+    ) -> object: ...
 
 class SSM:
     def get_parameter(

--- a/tagbot/web/__init__.py
+++ b/tagbot/web/__init__.py
@@ -102,5 +102,9 @@ def report() -> JSON:
             payload["manual_intervention_url"] = request.json["manual_intervention_url"]
     else:
         payload = {}
-    LAMBDA.invoke(FunctionName=REPORTS_FUNCTION_NAME, Payload=json.dumps(payload))
+    LAMBDA.invoke(
+        FunctionName=REPORTS_FUNCTION_NAME,
+        InvocationType="Event",
+        Payload=json.dumps(payload),
+    )
     return {"status": "Submitted error report"}, 200

--- a/template.yaml
+++ b/template.yaml
@@ -25,6 +25,15 @@ Globals:
         TAGBOT_REPO: !Ref TagbotRepo
         TAGBOT_ISSUES_REPO: !Ref TagbotIssuesRepo
         TAGBOT_COMMIT: !Ref TagbotCommit
+  Api:
+    # Stage-level throttling. The endpoint is intentionally keyless (TagBot runs
+    # cannot carry API keys), so this caps the request rate for all callers and
+    # bounds the GitHub API work a flood can trigger against the shared token.
+    MethodSettings:
+      - ResourcePath: "/*"
+        HttpMethod: "*"
+        ThrottlingBurstLimit: 20
+        ThrottlingRateLimit: 10
 
 Resources:
   ApiFunction:

--- a/test/web/test_web.py
+++ b/test/web/test_web.py
@@ -69,4 +69,6 @@ def test_report(LAMBDA, REPORTS, client):
     assert resp.status_code == 200
     assert resp.is_json
     assert resp.json == {"status": "Submitted error report"}
-    LAMBDA.invoke.assert_called_with(FunctionName=REPORTS, Payload=json.dumps(payload))
+    LAMBDA.invoke.assert_called_with(
+        FunctionName=REPORTS, InvocationType="Event", Payload=json.dumps(payload)
+    )


### PR DESCRIPTION
Claude:

The /report endpoint is intentionally keyless (TagBot runs cannot carry API keys), so run verification rejects forged reports but cannot bound request volume. A flood still costs GitHub API calls (the run lookup plus the dedup scan) against the single shared bot token.

- Add stage-level API Gateway throttling (burst 20, rate 10/s) so the rate is capped for all callers without requiring API keys.
- Invoke the reports Lambda with InvocationType=Event (async) so the API request returns immediately instead of blocking on the report work, which also reduces flood amplification and the timeout mismatch between the two functions.