### PR TITLE
Fix slow changelog generation for historical releases

### DIFF
--- a/tagbot/action/changelog.py
+++ b/tagbot/action/changelog.py
@@ -113,6 +113,10 @@ class Changelog:
         prev_rel = None
         latest_time = datetime.min.replace(tzinfo=timezone.utc)
         tags = self._repo.get_all_tags()
+        # Resolve every tag's commit time in a single git call instead of one
+        # API/subprocess round-trip per tag, which is O(tags) slow on large
+        # registries (see issue #578).
+        tag_times = self._repo._git.commit_times_of_tags()
 
         for tag_name in tags:
             if not tag_name.startswith(tag_prefix):
@@ -126,11 +130,12 @@ class Changelog:
             if ver > cur_ver or ver == cur_ver:
                 continue
             # Get the release time
-            try:
-                rel = self._repo._repo.get_release(tag_name)
-                rel_time = _ensure_utc(rel.created_at)
-            except UnknownObjectException:
-                rel_time = _ensure_utc(self._repo._git.time_of_commit(tag_name))
+            commit_time = tag_times.get(tag_name)
+            if commit_time is None:
+                # Missing from the batch lookup (e.g. a just-created tag); fall
+                # back to a single-tag git query.
+                commit_time = self._repo._git.time_of_commit(tag_name)
+            rel_time = _ensure_utc(commit_time)
             if rel_time < commit_date and rel_time > latest_time:
                 prev_rel = type(
                     "obj",

--- a/tagbot/action/git.py
+++ b/tagbot/action/git.py
@@ -3,7 +3,7 @@ import subprocess
 
 from datetime import datetime, timezone
 from tempfile import mkdtemp
-from typing import Optional, cast
+from typing import Dict, Optional, cast
 from urllib.parse import urlparse
 
 from .. import logger
@@ -261,3 +261,31 @@ class Git:
             )
             return datetime.now(timezone.utc).replace(tzinfo=None)
         return parsed
+
+    def commit_times_of_tags(self, repo: str = "") -> Dict[str, datetime]:
+        """Return a map of tag name to its underlying commit's datetime.
+
+        Uses a single ``git for-each-ref`` call rather than one lookup per tag,
+        which matters for repositories with many tags (see issue #578).
+        """
+        # For annotated tags the dereferenced (``*``) committer date is the
+        # underlying commit's date; for lightweight tags the direct committer
+        # date already points at the commit. Exactly one is populated per tag.
+        fmt = (
+            "%(refname:short)%09%(committerdate:iso-strict)"
+            "%09%(*committerdate:iso-strict)"
+        )
+        output = self.command("for-each-ref", f"--format={fmt}", "refs/tags", repo=repo)
+        times: Dict[str, datetime] = {}
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            if len(parts) < 2:
+                continue
+            name = parts[0]
+            deref = parts[2] if len(parts) > 2 else ""
+            parsed = parse_git_datetime(deref or parts[1])
+            if parsed:
+                times[name] = parsed
+        return times

--- a/test/action/test_changelog.py
+++ b/test/action/test_changelog.py
@@ -646,40 +646,57 @@ def test_previous_release_chronological():
     """Test finding chronologically previous releases."""
     c = _changelog()
     c._repo.get_all_tags = Mock(return_value=["v1.0.0", "v2.0.0", "v1.5.0"])
-    c._repo._repo.get_release = Mock()
-    c._repo._git.time_of_commit = Mock()
 
     # Mock releases with different dates
     early_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
     middle_date = datetime(2023, 6, 1, tzinfo=timezone.utc)
     late_date = datetime(2023, 12, 1, tzinfo=timezone.utc)
 
-    # v1.0.0 released early
-    rel1 = Mock()
-    rel1.created_at = early_date
-    # v1.5.0 released middle
-    rel2 = Mock()
-    rel2.created_at = middle_date
+    c._repo._git.commit_times_of_tags = Mock(
+        return_value={"v1.0.0": early_date, "v1.5.0": middle_date}
+    )
 
     # For v2.0.0, should find v1.5.0 (latest before late_date)
-    c._repo._repo.get_release.side_effect = [rel1, rel2]  # v1.0.0, v1.5.0
     result = c._previous_release_chronological("v2.0.0", late_date)
     assert result.tag_name == "v1.5.0"
     assert result.created_at == middle_date
 
     # No previous release before commit_date
     early_commit = datetime(2022, 1, 1, tzinfo=timezone.utc)
-    c._repo._repo.get_release.side_effect = [rel1]  # only v1.0.0 < v1.5.0
     result = c._previous_release_chronological("v1.5.0", early_commit)
     assert result is None
 
-    # Skip versions >= current (no get_release calls expected)
-    c._repo._repo.get_release.side_effect = []
+    # Skip versions >= current
     result = c._previous_release_chronological("v1.0.0", late_date)
     assert result is None
 
     # Handle prerelease versions (should be skipped)
     c._repo.get_all_tags.return_value = ["v1.0.0", "v1.5.0-alpha", "v1.5.0"]
-    c._repo._repo.get_release.side_effect = [rel1, rel2]  # v1.0.0, v1.5.0
     result = c._previous_release_chronological("v2.0.0", late_date)
     assert result.tag_name == "v1.5.0"  # Should skip v1.5.0-alpha
+
+
+def test_previous_release_chronological_single_git_call():
+    """Regression for #578: resolve tag times in one batch git call.
+
+    Large registries must not trigger a per-tag get_release / time_of_commit
+    lookup, which made historical releases take minutes to generate.
+    """
+    c = _changelog()
+    many_tags = [f"v1.0.{i}" for i in range(50)]
+    c._repo.get_all_tags = Mock(return_value=many_tags)
+    base = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    times = {tag: base + timedelta(days=i) for i, tag in enumerate(many_tags)}
+    c._repo._git.commit_times_of_tags = Mock(return_value=times)
+    c._repo._repo.get_release = Mock(side_effect=AssertionError("get_release called"))
+    c._repo._git.time_of_commit = Mock(
+        side_effect=AssertionError("time_of_commit called")
+    )
+
+    commit_date = base + timedelta(days=100)
+    result = c._previous_release_chronological("v1.0.49", commit_date)
+
+    c._repo._git.commit_times_of_tags.assert_called_once_with()
+    assert result is not None
+    # The newest tag strictly older than the current version (v1.0.49).
+    assert result.tag_name == "v1.0.48"

--- a/test/action/test_git.py
+++ b/test/action/test_git.py
@@ -167,6 +167,29 @@ def test_time_of_commit():
     g.command.assert_called_with("log", "-1", "--format=%cI", "a^{commit}", repo="")
 
 
+def test_commit_times_of_tags():
+    output = (
+        "v1.0.0\t2023-01-01T00:00:00+00:00\t\n"
+        # Annotated tag: direct date is the tag date, deref date is the commit.
+        "v1.1.0\t2023-06-02T00:00:00+00:00\t2023-06-01T00:00:00+00:00\n"
+        "\n"
+        "bad-line\n"
+    )
+    g = _git(command=output)
+    times = g.commit_times_of_tags()
+    assert times == {
+        "v1.0.0": datetime(2023, 1, 1),
+        "v1.1.0": datetime(2023, 6, 1),
+    }
+    g.command.assert_called_with(
+        "for-each-ref",
+        "--format=%(refname:short)%09%(committerdate:iso-strict)"
+        "%09%(*committerdate:iso-strict)",
+        "refs/tags",
+        repo="",
+    )
+
+
 @patch("subprocess.run")
 def test_command_includes_hint(run):
     g = Git("", "Foo/Bar", "", "user", "email")


### PR DESCRIPTION
Fixes #578

Claude:

---

`_previous_release_chronological` looped over every tag and made a `get_release` API call (404 for most) plus a `git log` subprocess per tag. On a registry with hundreds of tags this took minutes (~289s for 639 tags), neither of which was reflected in the API-call perf counter.

Add `Git.commit_times_of_tags`, which resolves every tag's underlying commit datetime in a single `git for-each-ref` call (handling both lightweight and annotated tags), and use it for the chronological predecessor lookup with a single-tag fallback for tags missing from the batch.